### PR TITLE
Object list list entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ static def buildTime() {
 }
 
 dependencies {
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    compileOnly 'org.jetbrains:annotations:18.0.0'
 
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.text.SimpleDateFormat
 
 plugins {
-    id 'fabric-loom' version '0.2.5-SNAPSHOT'
+    id 'fabric-loom' version '0.2.6-SNAPSHOT'
     id 'maven-publish'
     id 'maven'
     id 'signing'
@@ -9,12 +9,21 @@ plugins {
     id 'com.matthewprenger.cursegradle' version '1.4.0'
 }
 
+repositories {
+    maven {
+        name = 'Fabric'
+        url = 'https://maven.fabricmc.net/'
+    }
+    jcenter()
+    maven { url "https://jitpack.io" }
+}
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = "me.shedaniel.cloth"
 archivesBaseName = "config-2"
-version = ((String) project.mod_version).contains("unstable") ? (project.mod_version + "." + buildTime()) : project.mod_version
+version = (project.mod_version as String).contains("unstable") ? (project.mod_version + "." + buildTime()) : project.mod_version as String
 
 minecraft {
 }
@@ -33,14 +42,19 @@ static def buildTime() {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_version}"
-    modApi "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
-    modApi "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-    modImplementation "io.github.prospector:modmenu:${modmenu_version}"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    //https://github.com/natanfudge/Not-Enough-Crashes/blob/master/README.md
-    modCompileOnly "com.lettuce.fudge:notenoughcrashes:$nec_version"
+
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+
+    modApi "net.fabricmc:fabric-loader:${project.loader_version}"
+    modApi "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+    modImplementation "io.github.prospector:modmenu:${modmenu_version}"
+
+    modImplementation "com.lettuce.fudge:notenoughcrashes-api:1.0.0"
+    include "com.lettuce.fudge:notenoughcrashes-api:1.0.0"
+    modRuntime "com.lettuce.fudge:notenoughcrashes:$nec_version"
 }
 
 bintray {
@@ -145,7 +159,8 @@ curseforge {
         project {
             id = '319057'
             releaseType = 'release'
-            addGameVersion '1.15-Snapshot'
+            addGameVersion '1.15.1'
+            addGameVersion 'Fabric'
             addGameVersion 'Java 8'
             relations {
                 requiredDependency 'fabric-api'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-minecraft_version=1.15
-yarn_version=1.15+build.1
-fabric_loader_version=0.7.2+build.174
-fabric_version=0.4.20+build.273-1.15
+minecraft_version=1.15.1
+yarn_mappings=1.15.1+build.37
+loader_version=0.7.4+build.177
+fabric_version=0.4.28+build.288-1.15
 mod_version=2.8.0
-modmenu_version=1.7.14-unstable.19w42a+build.10
-nec_version=1.1.5+1.15.1
+modmenu_version=1.8.4+build.20
+nec_version=1.2.3+1.15.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ minecraft_version=1.15
 yarn_version=1.15+build.1
 fabric_loader_version=0.7.2+build.174
 fabric_version=0.4.20+build.273-1.15
-mod_version=2.7.1
+mod_version=2.8.0
 modmenu_version=1.7.14-unstable.19w42a+build.10
 nec_version=1.1.5+1.15.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip

--- a/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
+++ b/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
@@ -267,7 +267,7 @@ public class ClothConfigInitializer implements ClientModInitializer {
                         testing.addEntry(entryBuilder.startKeyCodeField("Cool Key", InputUtil.UNKNOWN_KEYCODE).setDefaultValue(InputUtil.UNKNOWN_KEYCODE).build());
                         testing.addEntry(entryBuilder.startModifierKeyCodeField("Cool Modifier Key", ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).setDefaultValue(ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).build());
                         testing.addEntry(
-                                entryBuilder.startDoubleList("A list of Doubles", new ArrayList<>())
+                                entryBuilder.startDoubleList("A list of Doubles", Arrays.asList(1.0, 2.0))
                                         .setDefaultValue(Arrays.asList(1.0, 2.0))
                                         .build()
                         );

--- a/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
+++ b/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
@@ -267,8 +267,18 @@ public class ClothConfigInitializer implements ClientModInitializer {
                         testing.addEntry(entryBuilder.startKeyCodeField("Cool Key", InputUtil.UNKNOWN_KEYCODE).setDefaultValue(InputUtil.UNKNOWN_KEYCODE).build());
                         testing.addEntry(entryBuilder.startModifierKeyCodeField("Cool Modifier Key", ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).setDefaultValue(ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).build());
                         testing.addEntry(
-                                entryBuilder.startDoubleList("A list of Doubles", Arrays.asList(1.0, 2.0))
-                                        .setDefaultValue(Arrays.asList(1.0, 2.0))
+                                entryBuilder.startDoubleList("A list of Doubles", Arrays.asList(1d, 2d, 3d))
+                                        .setDefaultValue(Arrays.asList(1d, 2d, 3d))
+                                        .build()
+                        );
+                        testing.addEntry(
+                                entryBuilder.startLongList("A list of Longs", Arrays.asList(1L, 2L, 3L))
+                                        .setDefaultValue(Arrays.asList(1L, 2L, 3L))
+                                        .build()
+                        );
+                        testing.addEntry(
+                                entryBuilder.startStrList("A list of Strings", Arrays.asList("abc", "xyz"))
+                                        .setDefaultValue(Arrays.asList("abc", "xyz"))
                                         .build()
                         );
                         builder.setSavingRunnable(ClothConfigInitializer::saveConfig);

--- a/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
+++ b/src/main/java/me/shedaniel/clothconfig2/ClothConfigInitializer.java
@@ -36,15 +36,14 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("unchecked")
 public class ClothConfigInitializer implements ClientModInitializer {
-    
+
     public static final Logger LOGGER = LogManager.getFormatterLogger("ClothConfig");
     private static EasingMethod easingMethod = EasingMethodImpl.LINEAR;
     private static long scrollDuration = 600;
     private static double scrollStep = 19;
     private static double bounceBackMultiplier = .24;
-    
+
     public static double handleScrollingPosition(double[] target, double scroll, double maxScroll, float delta, double start, double duration) {
         if (getBounceBackMultiplier() >= 0) {
             target[0] = clamp(target[0], maxScroll);
@@ -60,51 +59,39 @@ public class ClothConfigInitializer implements ClientModInitializer {
         else
             return target[0];
     }
-    
+
     public static double expoEase(double start, double end, double amount) {
         return start + (end - start) * getEasingMethod().apply(amount);
     }
-    
-    public static class Precision {
-        public static final float FLOAT_EPSILON = 1e-3f;
-        public static final double DOUBLE_EPSILON = 1e-7;
-        
-        public static boolean almostEquals(float value1, float value2, float acceptableDifference) {
-            return Math.abs(value1 - value2) <= acceptableDifference;
-        }
-        
-        public static boolean almostEquals(double value1, double value2, double acceptableDifference) {
-            return Math.abs(value1 - value2) <= acceptableDifference;
-        }
-    }
-    
+
     public static double clamp(double v, double maxScroll) {
         return clamp(v, maxScroll, DynamicEntryListWidget.SmoothScrollingSettings.CLAMP_EXTENSION);
     }
-    
+
     public static double clamp(double v, double maxScroll, double clampExtension) {
         return MathHelper.clamp(v, -clampExtension, maxScroll + clampExtension);
     }
-    
+
     public static EasingMethod getEasingMethod() {
         return easingMethod;
     }
-    
+
     public static long getScrollDuration() {
         return scrollDuration;
     }
-    
+
     public static double getScrollStep() {
         return scrollStep;
     }
-    
+
     public static double getBounceBackMultiplier() {
         return bounceBackMultiplier;
     }
-    
+
     private static void loadConfig() {
         File file = new File(FabricLoader.getInstance().getConfigDirectory(), "cloth-config2/config.properties");
         try {
+            //noinspection ResultOfMethodCallIgnored
             file.getParentFile().mkdirs();
             easingMethod = EasingMethodImpl.LINEAR;
             scrollDuration = 600;
@@ -138,7 +125,7 @@ public class ClothConfigInitializer implements ClientModInitializer {
         }
         saveConfig();
     }
-    
+
     private static void saveConfig() {
         File file = new File(FabricLoader.getInstance().getConfigDirectory(), "cloth-config2/config.properties");
         try {
@@ -158,7 +145,7 @@ public class ClothConfigInitializer implements ClientModInitializer {
             bounceBackMultiplier = .24;
         }
     }
-    
+
     @Override
     public void onInitializeClient() {
         loadConfig();
@@ -177,11 +164,11 @@ public class ClothConfigInitializer implements ClientModInitializer {
                                 if (m.toString().equals(str))
                                     return m;
                             return null;
-                        })).setDefaultValue(EasingMethodImpl.LINEAR).setSaveConsumer(o -> easingMethod = (EasingMethod) o).setSelections(EasingMethods.getMethods()).build();
+                        })).setDefaultValue(EasingMethodImpl.LINEAR).setSaveConsumer(o -> easingMethod = o).setSelections(EasingMethods.getMethods()).build();
                         LongSliderEntry scrollDurationEntry = entryBuilder.startLongSlider("option.cloth-config.scrollDuration", scrollDuration, 0, 5000).setTextGetter(integer -> integer <= 0 ? "Value: Disabled" : (integer > 1500 ? String.format("Value: %.1fs", integer / 1000f) : "Value: " + integer + "ms")).setDefaultValue(600).setSaveConsumer(i -> scrollDuration = i).build();
                         DoubleListEntry scrollStepEntry = entryBuilder.startDoubleField("option.cloth-config.scrollStep", scrollStep).setDefaultValue(19).setSaveConsumer(i -> scrollStep = i).build();
                         LongSliderEntry bounceMultiplierEntry = entryBuilder.startLongSlider("option.cloth-config.bounceBackMultiplier", (long) (bounceBackMultiplier * 1000), -10, 750).setTextGetter(integer -> integer < 0 ? "Value: Disabled" : String.format("Value: %s", integer / 1000d)).setDefaultValue(240).setSaveConsumer(i -> bounceBackMultiplier = i / 1000d).build();
-                        
+
                         scrolling.addEntry(new TooltipListEntry<Object>(I18n.translate("option.cloth-config.setDefaultSmoothScroll"), null) {
                             int width = 220;
                             private AbstractButtonWidget buttonWidget = new AbstractPressableButtonWidget(0, 0, 0, 20, getFieldName()) {
@@ -195,26 +182,26 @@ public class ClothConfigInitializer implements ClientModInitializer {
                                 }
                             };
                             private List<AbstractButtonWidget> children = ImmutableList.of(buttonWidget);
-                            
+
                             @Override
                             public Object getValue() {
                                 return null;
                             }
-                            
+
                             @Override
                             public Optional<Object> getDefaultValue() {
                                 return Optional.empty();
                             }
-                            
+
                             @Override
                             public void save() {
                             }
-                            
+
                             @Override
                             public List<? extends Element> children() {
                                 return children;
                             }
-                            
+
                             @Override
                             public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
                                 super.render(index, y, x, entryWidth, entryHeight, mouseX, mouseY, isSelected, delta);
@@ -226,7 +213,7 @@ public class ClothConfigInitializer implements ClientModInitializer {
                                 this.buttonWidget.render(mouseX, mouseY, delta);
                             }
                         });
-                        
+
                         scrolling.addEntry(new TooltipListEntry<Object>(I18n.translate("option.cloth-config.disableSmoothScroll"), null) {
                             int width = 220;
                             private AbstractButtonWidget buttonWidget = new AbstractPressableButtonWidget(0, 0, 0, 20, getFieldName()) {
@@ -240,26 +227,26 @@ public class ClothConfigInitializer implements ClientModInitializer {
                                 }
                             };
                             private List<AbstractButtonWidget> children = ImmutableList.of(buttonWidget);
-                            
+
                             @Override
                             public Object getValue() {
                                 return null;
                             }
-                            
+
                             @Override
                             public Optional<Object> getDefaultValue() {
                                 return Optional.empty();
                             }
-                            
+
                             @Override
                             public void save() {
                             }
-                            
+
                             @Override
                             public List<? extends Element> children() {
                                 return children;
                             }
-                            
+
                             @Override
                             public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
                                 super.render(index, y, x, entryWidth, entryHeight, mouseX, mouseY, isSelected, delta);
@@ -279,6 +266,11 @@ public class ClothConfigInitializer implements ClientModInitializer {
                         testing.addEntry(entryBuilder.startDropdownMenu("lol apple", DropdownMenuBuilder.TopCellElementBuilder.ofItemObject(Items.APPLE), DropdownMenuBuilder.CellCreatorBuilder.ofItemObject()).setDefaultValue(Items.APPLE).setSelections(Registry.ITEM.stream().sorted(Comparator.comparing(Item::toString)).collect(Collectors.toCollection(LinkedHashSet::new))).setSaveConsumer(item -> System.out.println("save this " + item)).build());
                         testing.addEntry(entryBuilder.startKeyCodeField("Cool Key", InputUtil.UNKNOWN_KEYCODE).setDefaultValue(InputUtil.UNKNOWN_KEYCODE).build());
                         testing.addEntry(entryBuilder.startModifierKeyCodeField("Cool Modifier Key", ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).setDefaultValue(ModifierKeyCode.of(InputUtil.Type.KEYSYM.createFromCode(79), Modifier.of(false, true, false))).build());
+                        testing.addEntry(
+                                entryBuilder.startDoubleList("A list of Doubles", new ArrayList<>())
+                                        .setDefaultValue(Arrays.asList(1.0, 2.0))
+                                        .build()
+                        );
                         builder.setSavingRunnable(ClothConfigInitializer::saveConfig);
                         builder.transparentBackground();
                         MinecraftClient.getInstance().openScreen(builder.build());
@@ -295,5 +287,18 @@ public class ClothConfigInitializer implements ClientModInitializer {
             //            });
         }
     }
-    
+
+    public static class Precision {
+        public static final float FLOAT_EPSILON = 1e-3f;
+        public static final double DOUBLE_EPSILON = 1e-7;
+
+        public static boolean almostEquals(float value1, float value2, float acceptableDifference) {
+            return Math.abs(value1 - value2) <= acceptableDifference;
+        }
+
+        public static boolean almostEquals(double value1, double value2, double acceptableDifference) {
+            return Math.abs(value1 - value2) <= acceptableDifference;
+        }
+    }
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/ClothConfigScreen.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/ClothConfigScreen.java
@@ -28,8 +28,8 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.Tickable;
 import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,9 +65,10 @@ public abstract class ClothConfigScreen extends Screen {
     private Map<String, Identifier> categoryBackgroundLocation;
     private boolean transparentBackground = false;
     private boolean editable = true;
-    @Nullable private String defaultFallbackCategory = null;
+    @Nullable
+    private String defaultFallbackCategory = null;
     private boolean alwaysShowTabs = false;
-    
+
     @Deprecated
     public ClothConfigScreen(Screen parent, String title, Map<String, List<Pair<String, Object>>> o, boolean confirmSave, boolean displayErrors, boolean smoothScrollingList, Identifier defaultBackgroundLocation, Map<String, Identifier> categoryBackgroundLocation) {
         super(new LiteralText(""));

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -75,6 +75,7 @@ public abstract class AbstractListListEntry<T, C extends AbstractListListEntry.A
 
         public AbstractListCell(@Nullable T value, OUTER_SELF listListEntry) {
             this.listListEntry = listListEntry;
+            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(cellErrorFn -> cellErrorFn.apply(this.getValue())));
         }
 
         public abstract T getValue();

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -54,7 +54,7 @@ public abstract class AbstractListListEntry<T, C extends AbstractListListEntry.A
 
     @Override
     public List<T> getValue() {
-        return cells.stream().map(AbstractListCell::getValue).collect(Collectors.toList());
+        return cells.stream().map(C::getValue).collect(Collectors.toList());
     }
 
     @Override
@@ -69,7 +69,8 @@ public abstract class AbstractListListEntry<T, C extends AbstractListListEntry.A
      * @see AbstractListListEntry
      */
     @ApiStatus.Internal
-    public static abstract class AbstractListCell<T, SELF extends AbstractListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractListListEntry<T, SELF, OUTER_SELF>> extends BaseListCell {
+    public static abstract class AbstractListCell<T, SELF extends AbstractListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractListListEntry<T, SELF, OUTER_SELF>>
+            extends BaseListCell {
         protected final OUTER_SELF listListEntry;
 
         public AbstractListCell(@Nullable T value, OUTER_SELF listListEntry) {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -1,0 +1,75 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * @param <T>    the configuration object type
+ * @param <C>    the cell type
+ * @param <SELF> the "curiously recurring template pattern" type parameter
+ * @see BaseListEntry
+ */
+abstract class AbstractListListEntry<T, C extends AbstractListListEntry.AbstractListCell<T, C, SELF>, SELF extends AbstractListListEntry<T, C, SELF>>
+        extends BaseListEntry<T, C, SELF> {
+
+    protected final BiFunction<T, SELF, C> createNewCell;
+    protected Function<T, Optional<String>> cellErrorSupplier;
+
+    @Deprecated
+    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false, null);
+    }
+
+    @Deprecated
+    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey, boolean requiresRestart, BiFunction<T, SELF, C> createNewCell) {
+        super(fieldName, tooltipSupplier, defaultValue, abstractListListEntry -> createNewCell.apply(null, abstractListListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this.createNewCell = createNewCell;
+        for (T f : value)
+            cells.add(createNewCell.apply(f, this.self()));
+        this.widgets.addAll(cells);
+        expended = defaultExpended;
+    }
+
+    public Function<T, Optional<String>> getCellErrorSupplier() {
+        return cellErrorSupplier;
+    }
+
+    public void setCellErrorSupplier(Function<T, Optional<String>> cellErrorSupplier) {
+        this.cellErrorSupplier = cellErrorSupplier;
+    }
+
+    @Override
+    public List<T> getValue() {
+        return cells.stream().map(AbstractListCell::getValue).collect(Collectors.toList());
+    }
+
+    @Override
+    protected C getFromValue(T value) {
+        return createNewCell.apply(value, this.self());
+    }
+
+    /**
+     * @param <T>           the configuration object type
+     * @param <SELF>        the "curiously recurring template pattern" type parameter for this class
+     * @param <OUTER_SELF>> the "curiously recurring template pattern" type parameter for the outer class
+     * @see AbstractListListEntry
+     */
+    static abstract class AbstractListCell<T, SELF extends AbstractListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractListListEntry<T, SELF, OUTER_SELF>> extends BaseListCell {
+        protected final T value;
+        protected final AbstractListListEntry<T, SELF, OUTER_SELF> listListEntry;
+
+        public AbstractListCell(T value, AbstractListListEntry<T, SELF, OUTER_SELF> listListEntry) {
+            this.value = value;
+            this.listListEntry = listListEntry;
+        }
+
+        public abstract T getValue();
+
+    }
+
+}

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -21,18 +21,13 @@ abstract class AbstractListListEntry<T, C extends AbstractListListEntry.Abstract
     protected Function<T, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false, null);
-    }
-
-    @Deprecated
-    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey, boolean requiresRestart, BiFunction<T, SELF, C> createNewCell) {
+    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey, boolean requiresRestart, BiFunction<T, SELF, C> createNewCell) {
         super(fieldName, tooltipSupplier, defaultValue, abstractListListEntry -> createNewCell.apply(null, abstractListListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.createNewCell = createNewCell;
         for (T f : value)
             cells.add(createNewCell.apply(f, this.self()));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
 
     public Function<T, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -1,5 +1,8 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -14,15 +17,26 @@ import java.util.stream.Collectors;
  * @param <SELF> the "curiously recurring template pattern" type parameter
  * @see BaseListEntry
  */
-abstract class AbstractListListEntry<T, C extends AbstractListListEntry.AbstractListCell<T, C, SELF>, SELF extends AbstractListListEntry<T, C, SELF>>
+@ApiStatus.Internal
+public abstract class AbstractListListEntry<T, C extends AbstractListListEntry.AbstractListCell<T, C, SELF>, SELF extends AbstractListListEntry<T, C, SELF>>
         extends BaseListEntry<T, C, SELF> {
 
     protected final BiFunction<T, SELF, C> createNewCell;
     protected Function<T, Optional<String>> cellErrorSupplier;
 
-    @Deprecated
-    public AbstractListListEntry(String fieldName, List<T> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, String resetButtonKey, boolean requiresRestart, BiFunction<T, SELF, C> createNewCell) {
-        super(fieldName, tooltipSupplier, defaultValue, abstractListListEntry -> createNewCell.apply(null, abstractListListEntry), saveConsumer, resetButtonKey, requiresRestart);
+    public AbstractListListEntry(
+            String fieldName,
+            List<T> value,
+            boolean defaultExpanded,
+            Supplier<Optional<String[]>> tooltipSupplier,
+            Consumer<List<T>> saveConsumer,
+            Supplier<List<T>> defaultValue,
+            String resetButtonKey,
+            boolean requiresRestart,
+            boolean deleteButtonEnabled,
+            boolean insertInFront,
+            BiFunction<T, SELF, C> createNewCell) {
+        super(fieldName, tooltipSupplier, defaultValue, abstractListListEntry -> createNewCell.apply(null, abstractListListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         this.createNewCell = createNewCell;
         for (T f : value)
             cells.add(createNewCell.apply(f, this.self()));
@@ -54,12 +68,11 @@ abstract class AbstractListListEntry<T, C extends AbstractListListEntry.Abstract
      * @param <OUTER_SELF>> the "curiously recurring template pattern" type parameter for the outer class
      * @see AbstractListListEntry
      */
-    static abstract class AbstractListCell<T, SELF extends AbstractListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractListListEntry<T, SELF, OUTER_SELF>> extends BaseListCell {
-        protected final T value;
-        protected final AbstractListListEntry<T, SELF, OUTER_SELF> listListEntry;
+    @ApiStatus.Internal
+    public static abstract class AbstractListCell<T, SELF extends AbstractListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractListListEntry<T, SELF, OUTER_SELF>> extends BaseListCell {
+        protected final OUTER_SELF listListEntry;
 
-        public AbstractListCell(T value, AbstractListListEntry<T, SELF, OUTER_SELF> listListEntry) {
-            this.value = value;
+        public AbstractListCell(@Nullable T value, OUTER_SELF listListEntry) {
             this.listListEntry = listListEntry;
         }
 

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -1,0 +1,115 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * This class represents config entry lists that use one {@link TextFieldWidget} per entry.
+ *
+ * @param <T>    the configuration object type
+ * @param <C>    the cell type
+ * @param <SELF> the "curiously recurring template pattern" type parameter
+ * @see AbstractListListEntry
+ */
+@ApiStatus.Internal
+public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<T, C, SELF>, SELF extends AbstractTextFieldListListEntry<T, C, SELF>>
+        extends AbstractListListEntry<T, C, SELF> {
+
+    public AbstractTextFieldListListEntry(
+            String fieldName,
+            List<T> value,
+            boolean defaultExpanded,
+            Supplier<Optional<String[]>> tooltipSupplier,
+            Consumer<List<T>> saveConsumer,
+            Supplier<List<T>> defaultValue,
+            String resetButtonKey,
+            boolean requiresRestart,
+            boolean deleteButtonEnabled,
+            boolean insertInFront,
+            BiFunction<T, SELF, C> createNewCell
+    ) {
+        super(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, createNewCell);
+    }
+
+    /**
+     * @param <T>           the configuration object type
+     * @param <SELF>        the "curiously recurring template pattern" type parameter for this class
+     * @param <OUTER_SELF>> the "curiously recurring template pattern" type parameter for the outer class
+     * @see AbstractTextFieldListListEntry
+     */
+    @ApiStatus.Internal
+    public static abstract class AbstractTextFieldListCell<T, SELF extends AbstractTextFieldListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractTextFieldListListEntry<T, SELF, OUTER_SELF>> extends AbstractListListEntry.AbstractListCell<T, SELF, OUTER_SELF> {
+
+        protected TextFieldWidget widget;
+
+        public AbstractTextFieldListCell(@Nullable T value, OUTER_SELF listListEntry) {
+            super(value, listListEntry);
+
+            final T finalValue = substituteDefault(value);
+
+            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
+            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(cellErrorFn -> cellErrorFn.apply(this.getValue())));
+            widget.setTextPredicate(this::isValidText);
+            widget.setMaxLength(Integer.MAX_VALUE);
+            widget.setHasBorder(false);
+            widget.setText(Objects.toString(finalValue));
+            widget.setChangedListener(s -> {
+                widget.setEditableColor(getPreferredTextColor());
+                if (!Objects.equals(s, Objects.toString(finalValue))) {
+                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
+                }
+            });
+        }
+
+        /**
+         * Allows subclasses to substitute default values.
+         *
+         * @param value the (possibly null) value to substitute
+         * @return a substitution
+         */
+        @Nullable
+        protected abstract T substituteDefault(@Nullable T value);
+
+        /**
+         * Tests if the text entered is valid. If not, the text is not changed.
+         *
+         * @param text the text to test
+         * @return {@code true} if the text may be changed, {@code false} to prevent the change
+         */
+        protected abstract boolean isValidText(@NotNull String text);
+
+        @Override
+        public int getCellHeight() {
+            return 20;
+        }
+
+        @Override
+        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
+            widget.setWidth(entryWidth - 12);
+            widget.x = x;
+            widget.y = y + 1;
+            widget.setEditable(listListEntry.isEditable());
+            widget.render(mouseX, mouseY, delta);
+            if (isSelected && listListEntry.isEditable())
+                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
+        }
+
+        @Override
+        public List<? extends Element> children() {
+            return Collections.singletonList(widget);
+        }
+    }
+
+}

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * This class represents config entry lists that use one {@link TextFieldWidget} per entry.
@@ -44,11 +43,6 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
         super(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, createNewCell);
     }
 
-    @Override
-    public List<T> getValue() {
-        return cells.stream().map(C::getValue).collect(Collectors.toList());
-    }
-
     /**
      * @param <T>           the configuration object type
      * @param <SELF>        the "curiously recurring template pattern" type parameter for this class
@@ -56,7 +50,8 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
      * @see AbstractTextFieldListListEntry
      */
     @ApiStatus.Internal
-    public static abstract class AbstractTextFieldListCell<T, SELF extends AbstractTextFieldListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractTextFieldListListEntry<T, SELF, OUTER_SELF>> extends AbstractListListEntry.AbstractListCell<T, SELF, OUTER_SELF> {
+    public static abstract class AbstractTextFieldListCell<T, SELF extends AbstractTextFieldListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractTextFieldListListEntry<T, SELF, OUTER_SELF>>
+            extends AbstractListListEntry.AbstractListCell<T, SELF, OUTER_SELF> {
 
         protected TextFieldWidget widget;
 

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * This class represents config entry lists that use one {@link TextFieldWidget} per entry.
@@ -41,6 +42,11 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
             BiFunction<T, SELF, C> createNewCell
     ) {
         super(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, createNewCell);
+    }
+
+    @Override
+    public List<T> getValue() {
+        return cells.stream().map(C::getValue).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -61,7 +61,6 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
             final T finalValue = substituteDefault(value);
 
             widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(cellErrorFn -> cellErrorFn.apply(this.getValue())));
             widget.setTextPredicate(this::isValidText);
             widget.setMaxLength(Integer.MAX_VALUE);
             widget.setHasBorder(false);

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * @param <T>    the configuration object type
@@ -129,14 +130,16 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
 
     @Override
     public Optional<String> getError() {
-        String error = null;
-        for (BaseListCell entry : cells)
-            if (entry.getConfigError().isPresent()) {
-                if (error != null)
-                    return Optional.ofNullable(I18n.translate("text.cloth-config.multi_error"));
-                return Optional.ofNullable((String) entry.getConfigError().get());
-            }
-        return Optional.ofNullable(error);
+        List<String> errors = cells.stream()
+                .map(C::getConfigError)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        if (errors.size() > 1)
+            return Optional.of(I18n.translate("text.cloth-config.multi_error"));
+        else
+            return errors.stream().findFirst();
     }
 
     @Override

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -14,6 +14,7 @@ import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,12 +28,15 @@ import java.util.function.Supplier;
  * @param <SELF> the "curiously recurring template pattern" type parameter
  * @implNote See <a href="https://stackoverflow.com/questions/7354740/is-there-a-way-to-refer-to-the-current-type-with-a-type-variable">Is there a way to refer to the current type with a type variable?</href> on Stack Overflow.
  */
+@ApiStatus.Internal
 public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends BaseListEntry<T, C, SELF>> extends TooltipListEntry<List<T>> {
 
     protected static final Identifier CONFIG_TEX = new Identifier("cloth-config2", "textures/gui/cloth_config.png");
     protected final List<C> cells;
     protected final List<Element> widgets;
     protected boolean expanded;
+    protected boolean deleteButtonEnabled;
+    protected boolean insertInFront;
     protected Consumer<List<T>> saveConsumer;
     protected ListLabelWidget labelWidget;
     protected AbstractButtonWidget resetWidget;
@@ -45,8 +49,15 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         this(fieldName, tooltipSupplier, defaultValue, createNewInstance, saveConsumer, resetButtonKey, false);
     }
 
+    @Deprecated
     public BaseListEntry(String fieldName, Supplier<Optional<String[]>> tooltipSupplier, Supplier<List<T>> defaultValue, Function<SELF, C> createNewInstance, Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart) {
+        this(fieldName, tooltipSupplier, defaultValue, createNewInstance, saveConsumer, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public BaseListEntry(String fieldName, Supplier<Optional<String[]>> tooltipSupplier, Supplier<List<T>> defaultValue, Function<SELF, C> createNewInstance, Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
         super(fieldName, tooltipSupplier, requiresRestart);
+        this.deleteButtonEnabled = deleteButtonEnabled;
+        this.insertInFront = insertInFront;
         this.cells = Lists.newArrayList();
         this.labelWidget = new ListLabelWidget();
         this.widgets = Lists.newArrayList(labelWidget);
@@ -66,7 +77,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     public abstract SELF self();
 
     public boolean isDeleteButtonEnabled() {
-        return true;
+        return deleteButtonEnabled;
     }
 
     protected abstract C getFromValue(T value);
@@ -197,7 +208,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     }
 
     public boolean insertInFront() {
-        return true;
+        return insertInFront;
     }
 
     public class ListLabelWidget implements Element {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -32,7 +32,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     protected static final Identifier CONFIG_TEX = new Identifier("cloth-config2", "textures/gui/cloth_config.png");
     protected final List<C> cells;
     protected final List<Element> widgets;
-    protected boolean expended;
+    protected boolean expanded;
     protected Consumer<List<T>> saveConsumer;
     protected ListLabelWidget labelWidget;
     protected AbstractButtonWidget resetWidget;
@@ -102,7 +102,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
 
     @Override
     public int getItemHeight() {
-        if (expended) {
+        if (expanded) {
             int i = 24;
             for (BaseListCell entry : cells)
                 i += entry.getCellHeight();
@@ -175,10 +175,10 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         MinecraftClient.getInstance().getTextureManager().bindTexture(CONFIG_TEX);
         DiffuseLighting.disable();
         RenderSystem.color4f(1, 1, 1, 1);
-        BaseListCell focused = !expended || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+        BaseListCell focused = !expanded || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
         boolean insideCreateNew = isInsideCreateNew(mouseX, mouseY);
         boolean insideDelete = isInsideDelete(mouseX, mouseY);
-        blit(x - 15, y + 4, 24 + 9, (labelWidget.rectangle.contains(mouseX, mouseY) && !insideCreateNew && !insideDelete ? 18 : 0) + (expended ? 9 : 0), 9, 9);
+        blit(x - 15, y + 4, 24 + 9, (labelWidget.rectangle.contains(mouseX, mouseY) && !insideCreateNew && !insideDelete ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
         blit(x - 15 + 13, y + 4, 24 + 18, insideCreateNew ? 9 : 0, 9, 9);
         if (isDeleteButtonEnabled())
             blit(x - 15 + 26, y + 4, 24 + 27, focused == null ? 0 : insideDelete ? 18 : 9, 9, 9);
@@ -187,7 +187,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         resetWidget.active = isEditable() && getDefaultValue().isPresent();
         resetWidget.render(mouseX, mouseY, delta);
         MinecraftClient.getInstance().textRenderer.drawWithShadow(I18n.translate(getFieldName()), isDeleteButtonEnabled() ? x + 24 : x + 24 - 9, y + 5, labelWidget.rectangle.contains(mouseX, mouseY) && !resetWidget.isMouseOver(mouseX, mouseY) && !insideDelete && !insideCreateNew ? 0xffe6fe16 : getPreferredTextColor());
-        if (expended) {
+        if (expanded) {
             int yy = y + 24;
             for (BaseListCell cell : cells) {
                 cell.render(-1, yy, x + 14, entryWidth - 14, cell.getCellHeight(), mouseX, mouseY, getParent().getFocused() != null && getParent().getFocused().equals(this) && getFocused() != null && getFocused().equals(cell), delta);
@@ -208,7 +208,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
             if (resetWidget.isMouseOver(double_1, double_2)) {
                 return false;
             } else if (isInsideCreateNew(double_1, double_2)) {
-                expended = true;
+                expanded = true;
                 C cell;
                 if (insertInFront()) {
                     cells.add(0, cell = createNewInstance.apply(BaseListEntry.this.self()));
@@ -221,7 +221,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
                 MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
             } else if (isDeleteButtonEnabled() && isInsideDelete(double_1, double_2)) {
-                BaseListCell focused = !expended && getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+                BaseListCell focused = !expanded && getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
                 if (focused != null) {
                     cells.remove(focused);
                     widgets.remove(focused);
@@ -230,7 +230,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
                 }
                 return true;
             } else if (rectangle.contains(double_1, double_2)) {
-                expended = !expended;
+                expanded = !expanded;
                 MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
             }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -15,6 +15,8 @@ import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,29 +35,35 @@ import java.util.stream.Collectors;
 public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends BaseListEntry<T, C, SELF>> extends TooltipListEntry<List<T>> {
 
     protected static final Identifier CONFIG_TEX = new Identifier("cloth-config2", "textures/gui/cloth_config.png");
+    @NotNull
     protected final List<C> cells;
+    @NotNull
     protected final List<Element> widgets;
     protected boolean expanded;
     protected boolean deleteButtonEnabled;
     protected boolean insertInFront;
+    @Nullable
     protected Consumer<List<T>> saveConsumer;
     protected ListLabelWidget labelWidget;
     protected AbstractButtonWidget resetWidget;
+    @NotNull
     protected Function<SELF, C> createNewInstance;
+    @NotNull
     protected Supplier<List<T>> defaultValue;
+    @Nullable
     protected String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
 
     @Deprecated
-    public BaseListEntry(String fieldName, Supplier<Optional<String[]>> tooltipSupplier, Supplier<List<T>> defaultValue, Function<SELF, C> createNewInstance, Consumer<List<T>> saveConsumer, String resetButtonKey) {
+    public BaseListEntry(@NotNull String fieldName, @Nullable Supplier<Optional<String[]>> tooltipSupplier, @NotNull Supplier<List<T>> defaultValue, @NotNull Function<SELF, C> createNewInstance, @Nullable Consumer<List<T>> saveConsumer, String resetButtonKey) {
         this(fieldName, tooltipSupplier, defaultValue, createNewInstance, saveConsumer, resetButtonKey, false);
     }
 
     @Deprecated
-    public BaseListEntry(String fieldName, Supplier<Optional<String[]>> tooltipSupplier, Supplier<List<T>> defaultValue, Function<SELF, C> createNewInstance, Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart) {
+    public BaseListEntry(@NotNull String fieldName, @Nullable Supplier<Optional<String[]>> tooltipSupplier, @NotNull Supplier<List<T>> defaultValue, @NotNull Function<SELF, C> createNewInstance, @Nullable Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart) {
         this(fieldName, tooltipSupplier, defaultValue, createNewInstance, saveConsumer, resetButtonKey, requiresRestart, true, true);
     }
 
-    public BaseListEntry(String fieldName, Supplier<Optional<String[]>> tooltipSupplier, Supplier<List<T>> defaultValue, Function<SELF, C> createNewInstance, Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+    public BaseListEntry(@NotNull String fieldName, @Nullable Supplier<Optional<String[]>> tooltipSupplier, @NotNull Supplier<List<T>> defaultValue, @NotNull Function<SELF, C> createNewInstance, @Nullable Consumer<List<T>> saveConsumer, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
         super(fieldName, tooltipSupplier, requiresRestart);
         this.deleteButtonEnabled = deleteButtonEnabled;
         this.insertInFront = insertInFront;
@@ -83,27 +91,30 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
 
     protected abstract C getFromValue(T value);
 
+    @NotNull
     public Function<SELF, C> getCreateNewInstance() {
         return createNewInstance;
     }
 
-    public void setCreateNewInstance(Function<SELF, C> createNewInstance) {
+    public void setCreateNewInstance(@NotNull Function<SELF, C> createNewInstance) {
         this.createNewInstance = createNewInstance;
     }
 
+    @Nullable
     public String getAddTooltip() {
         return addTooltip;
     }
 
-    public void setAddTooltip(String addTooltip) {
+    public void setAddTooltip(@Nullable String addTooltip) {
         this.addTooltip = addTooltip;
     }
 
+    @Nullable
     public String getRemoveTooltip() {
         return removeTooltip;
     }
 
-    public void setRemoveTooltip(String removeTooltip) {
+    public void setRemoveTooltip(@Nullable String removeTooltip) {
         this.removeTooltip = removeTooltip;
     }
 

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -246,8 +246,9 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
                 MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
             } else if (isDeleteButtonEnabled() && isInsideDelete(double_1, double_2)) {
-                BaseListCell focused = !expanded && getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
-                if (focused != null) {
+                Element focused = getFocused();
+                if (expanded && focused instanceof BaseListCell) {
+                    //noinspection SuspiciousMethodCalls
                     cells.remove(focused);
                     widgets.remove(focused);
                     getScreen().setEdited(true, isRequiresRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
@@ -19,19 +19,19 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
     private Function<Double, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
+    public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
 
     @Deprecated
-    public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey, boolean requiresRestart) {
+    public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new DoubleListCell(0d, (DoubleListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Double.MAX_VALUE;
         this.maximum = Double.MAX_VALUE;
-        for(Double f : value)
+        for (Double f : value)
             cells.add(new DoubleListCell(f, this));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
     
     public Function<Double, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
@@ -33,15 +33,15 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
         this.widgets.addAll(cells);
         expanded = defaultExpanded;
     }
-    
+
     public Function<Double, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public void setCellErrorSupplier(Function<Double, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
     }
-    
+
     @Override
     public List<Double> getValue() {
         return cells.stream().map(DoubleListCell::getValue).collect(Collectors.toList());
@@ -73,17 +73,17 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
             StringBuilder stringBuilder_1 = new StringBuilder();
             char[] var2 = s.toCharArray();
             int var3 = var2.length;
-            
-            for(int var4 = 0; var4 < var3; ++var4)
+
+            for (int var4 = 0; var4 < var3; ++var4)
                 if (Character.isDigit(var2[var4]) || var2[var4] == '-' || var2[var4] == '.')
                     stringBuilder_1.append(var2[var4]);
-            
+
             return stringBuilder_1.toString();
         };
         private TextFieldWidget widget;
         private boolean isSelected;
         private DoubleListListEntry listListEntry;
-        
+
         public DoubleListCell(double value, DoubleListListEntry listListEntry) {
             this.listListEntry = listListEntry;
             this.setErrorSupplier(() -> listListEntry.cellErrorSupplier == null ? Optional.empty() : listListEntry.getCellErrorSupplier().apply(getValue()));
@@ -96,7 +96,7 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
                     super.render(int_1, int_2, Double_1);
                     setFocused(f);
                 }
-                
+
                 @Override
                 public void write(String string_1) {
                     super.write(stripCharacters.apply(string_1));
@@ -110,7 +110,7 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
                     listListEntry.getScreen().setEdited(true, listListEntry.isRequiresRestart());
             });
         }
-        
+
         public double getValue() {
             try {
                 return Double.valueOf(widget.getText());
@@ -118,7 +118,7 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
                 return 0d;
             }
         }
-        
+
         @Override
         public Optional<String> getError() {
             try {
@@ -132,12 +132,12 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
             }
             return Optional.empty();
         }
-        
+
         @Override
         public int getCellHeight() {
             return 20;
         }
-        
+
         @Override
         public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
             widget.setWidth(entryWidth - 12);
@@ -149,12 +149,12 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
             if (isSelected && listListEntry.isEditable())
                 fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(widget);
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
@@ -13,16 +13,16 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEntry.DoubleListCell> {
-    
+public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEntry.DoubleListCell, DoubleListListEntry> {
+
     private double minimum, maximum;
     private Function<Double, Optional<String>> cellErrorSupplier;
-    
+
     @Deprecated
     public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey) {
         this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
-    
+
     @Deprecated
     public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new DoubleListCell(0d, (DoubleListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
@@ -46,24 +46,29 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
     public List<Double> getValue() {
         return cells.stream().map(DoubleListCell::getValue).collect(Collectors.toList());
     }
-    
+
     public DoubleListListEntry setMaximum(Double maximum) {
         this.maximum = maximum;
         return this;
     }
-    
+
     public DoubleListListEntry setMinimum(Double minimum) {
         this.minimum = minimum;
         return this;
     }
-    
+
+    @Override
+    public DoubleListListEntry self() {
+        return this;
+    }
+
     @Override
     protected DoubleListCell getFromValue(Double value) {
         return new DoubleListCell(value, this);
     }
-    
+
     public static class DoubleListCell extends BaseListCell {
-        
+
         private Function<String, String> stripCharacters = s -> {
             StringBuilder stringBuilder_1 = new StringBuilder();
             char[] var2 = s.toCharArray();

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
@@ -1,21 +1,17 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class DoubleListListEntry extends AbstractListListEntry<Double, DoubleListListEntry.DoubleListCell, DoubleListListEntry> {
+public class DoubleListListEntry extends AbstractTextFieldListListEntry<Double, DoubleListListEntry.DoubleListCell, DoubleListListEntry> {
 
     private double minimum, maximum;
 
@@ -46,11 +42,6 @@ public class DoubleListListEntry extends AbstractListListEntry<Double, DoubleLis
         this.maximum = Double.POSITIVE_INFINITY;
     }
 
-    @Override
-    public List<Double> getValue() {
-        return cells.stream().map(DoubleListCell::getValue).collect(Collectors.toList());
-    }
-
     public DoubleListListEntry setMaximum(Double maximum) {
         this.maximum = maximum;
         return this;
@@ -66,34 +57,24 @@ public class DoubleListListEntry extends AbstractListListEntry<Double, DoubleLis
         return this;
     }
 
-    @Override
-    protected DoubleListCell getFromValue(Double value) {
-        return new DoubleListCell(value, this);
-    }
-
-    public static class DoubleListCell extends AbstractListListEntry.AbstractListCell<Double, DoubleListCell, DoubleListListEntry> {
-
-        private TextFieldWidget widget;
+    public static class DoubleListCell extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<Double, DoubleListCell, DoubleListListEntry> {
 
         public DoubleListCell(Double value, final DoubleListListEntry listListEntry) {
             super(value, listListEntry);
+        }
 
+        @Nullable
+        @Override
+        protected Double substituteDefault(@Nullable Double value) {
             if (value == null)
-                value = 0d;
-            Double finalValue = value;
+                return 0d;
+            else
+                return value;
+        }
 
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(fn -> fn.apply(this.getValue())));
-            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            widget.setTextPredicate(s -> s.chars().allMatch(c -> Character.isDigit(c) || c == '-' || c == '.'));
-            widget.setMaxLength(Integer.MAX_VALUE);
-            widget.setHasBorder(false);
-            widget.setText(value.toString());
-            widget.setChangedListener(s -> {
-                widget.setEditableColor(getPreferredTextColor());
-                if (!Objects.equals(s, finalValue.toString())) {
-                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
-                }
-            });
+        @Override
+        protected boolean isValidText(@NotNull String text) {
+            return text.chars().allMatch(c -> Character.isDigit(c) || c == '-' || c == '.');
         }
 
         public Double getValue() {
@@ -116,27 +97,6 @@ public class DoubleListListEntry extends AbstractListListEntry<Double, DoubleLis
                 return Optional.of(I18n.translate("text.cloth-config.error.not_valid_number_double"));
             }
             return Optional.empty();
-        }
-
-        @Override
-        public int getCellHeight() {
-            return 20;
-        }
-
-        @Override
-        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-            widget.setWidth(entryWidth - 12);
-            widget.x = x;
-            widget.y = y + 1;
-            widget.setEditable(listListEntry.isEditable());
-            widget.render(mouseX, mouseY, delta);
-            if (isSelected && listListEntry.isEditable())
-                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
-        }
-
-        @Override
-        public List<? extends Element> children() {
-            return Collections.singletonList(widget);
         }
 
     }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleListListEntry.java
@@ -25,7 +25,11 @@ public class DoubleListListEntry extends BaseListEntry<Double, DoubleListListEnt
 
     @Deprecated
     public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new DoubleListCell(0d, (DoubleListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public DoubleListListEntry(String fieldName, List<Double> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Double>> saveConsumer, Supplier<List<Double>> defaultValue, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new DoubleListCell(0d, (DoubleListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         this.minimum = -Double.MAX_VALUE;
         this.maximum = Double.MAX_VALUE;
         for (Double f : value)

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
@@ -23,9 +23,9 @@ import net.minecraft.client.render.VertexFormats;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.Window;
 import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -33,20 +33,22 @@ import java.util.function.Supplier;
 
 @SuppressWarnings("deprecation")
 public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
-    
+
     protected ButtonWidget resetButton;
     protected SelectionElement<T> selectionElement;
-    @Nonnull private Supplier<T> defaultValue;
-    @Nullable private Consumer<T> saveConsumer;
-    
+    @NotNull
+    private Supplier<T> defaultValue;
+    @Nullable
+    private Consumer<T> saveConsumer;
+
     @Deprecated
     public DropdownBoxEntry(String fieldName,
-            @Nonnull String resetButtonKey,
-            @Nullable Supplier<Optional<String[]>> tooltipSupplier, boolean requiresRestart,
-            @Nullable Supplier<T> defaultValue,
-            @Nullable Consumer<T> saveConsumer,
-            @Nullable Iterable<T> selections,
-            @Nonnull SelectionTopCellElement<T> topRenderer, @Nonnull SelectionCellCreator<T> cellCreator) {
+                            @NotNull String resetButtonKey,
+                            @Nullable Supplier<Optional<String[]>> tooltipSupplier, boolean requiresRestart,
+                            @Nullable Supplier<T> defaultValue,
+                            @Nullable Consumer<T> saveConsumer,
+                            @Nullable Iterable<T> selections,
+                            @NotNull SelectionTopCellElement<T> topRenderer, @NotNull SelectionCellCreator<T> cellCreator) {
         super(I18n.translate(fieldName), tooltipSupplier, requiresRestart);
         this.defaultValue = defaultValue;
         this.saveConsumer = saveConsumer;
@@ -56,7 +58,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         });
         this.selectionElement = new SelectionElement(this, new Rectangle(0, 0, 150, 20), new DefaultDropdownMenuElement(selections == null ? ImmutableList.of() : ImmutableList.copyOf(selections)), topRenderer, cellCreator);
     }
-    
+
     @Override
     public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
         super.render(index, y, x, entryWidth, entryHeight, mouseX, mouseY, isSelected, delta);
@@ -78,58 +80,58 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         resetButton.render(mouseX, mouseY, delta);
         selectionElement.render(mouseX, mouseY, delta);
     }
-    
-    @Nonnull
+
+    @NotNull
     public ImmutableList<T> getSelections() {
         return selectionElement.menu.getSelections();
     }
-    
+
     @Override
     public T getValue() {
         return selectionElement.getValue();
     }
-    
+
     @Deprecated
     public SelectionElement<T> getSelectionElement() {
         return selectionElement;
     }
-    
+
     @Override
     public Optional<T> getDefaultValue() {
         return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
     }
-    
+
     @Override
     public void save() {
         if (saveConsumer != null)
             saveConsumer.accept(getValue());
     }
-    
+
     @Override
     public List<? extends Element> children() {
         return Lists.newArrayList(selectionElement, resetButton);
     }
-    
+
     @Override
     public Optional<String> getError() {
         return selectionElement.topRenderer.getError();
     }
-    
+
     @Override
     public void lateRender(int mouseX, int mouseY, float delta) {
         selectionElement.lateRender(mouseX, mouseY, delta);
     }
-    
+
     @Override
     public int getMorePossibleHeight() {
         return selectionElement.getMorePossibleHeight();
     }
-    
+
     @Override
     public boolean mouseScrolled(double double_1, double double_2, double double_3) {
         return selectionElement.mouseScrolled(double_1, double_2, double_3);
     }
-    
+
     public static class SelectionElement<R> extends AbstractParentElement implements Drawable {
         protected Rectangle bounds;
         protected boolean active;
@@ -137,7 +139,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         protected DropdownBoxEntry<R> entry;
         protected DropdownMenuElement<R> menu;
         protected boolean dontReFocus = false;
-        
+
         public SelectionElement(DropdownBoxEntry<R> entry, Rectangle bounds, DropdownMenuElement<R> menu, SelectionTopCellElement<R> topRenderer, SelectionCellCreator<R> cellCreator) {
             this.bounds = bounds;
             this.entry = entry;
@@ -148,48 +150,48 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             this.topRenderer = Objects.requireNonNull(topRenderer);
             this.topRenderer.entry = entry;
         }
-        
+
         @Override
         public void render(int mouseX, int mouseY, float delta) {
             fill(bounds.x, bounds.y, bounds.x + bounds.width, bounds.y + bounds.height, -6250336);
             fill(bounds.x + 1, bounds.y + 1, bounds.x + bounds.width - 1, bounds.y + bounds.height - 1, -16777216);
             topRenderer.render(mouseX, mouseY, bounds.x, bounds.y, bounds.width, bounds.height, delta);
-            if (menu.isExpended())
+            if (menu.isExpanded())
                 menu.render(mouseX, mouseY, bounds, delta);
         }
-    
+
         @Deprecated
         public SelectionTopCellElement<R> getTopRenderer() {
             return topRenderer;
         }
-    
+
         @Override
         public boolean mouseScrolled(double double_1, double double_2, double double_3) {
-            if (menu.isExpended())
+            if (menu.isExpanded())
                 return menu.mouseScrolled(double_1, double_2, double_3);
             return false;
         }
-        
+
         public void lateRender(int mouseX, int mouseY, float delta) {
-            if (menu.isExpended())
+            if (menu.isExpanded())
                 menu.lateRender(mouseX, mouseY, delta);
         }
-        
+
         public int getMorePossibleHeight() {
-            if (menu.isExpended())
+            if (menu.isExpanded())
                 return menu.getHeight();
             return -1;
         }
-        
+
         public R getValue() {
             return topRenderer.getValue();
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Lists.newArrayList(topRenderer, menu);
         }
-        
+
         @Override
         public boolean mouseClicked(double double_1, double double_2, int int_1) {
             dontReFocus = false;
@@ -201,90 +203,97 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             return b;
         }
     }
-    
+
     public static abstract class DropdownMenuElement<R> extends AbstractParentElement {
-        @Deprecated @Nonnull private SelectionCellCreator<R> cellCreator;
-        @Deprecated @Nonnull private DropdownBoxEntry<R> entry;
-        
-        @Nonnull
+        @Deprecated
+        @NotNull
+        private SelectionCellCreator<R> cellCreator;
+        @Deprecated
+        @NotNull
+        private DropdownBoxEntry<R> entry;
+
+        @NotNull
         public SelectionCellCreator<R> getCellCreator() {
             return cellCreator;
         }
-        
-        @Nonnull
+
+        @NotNull
         public final DropdownBoxEntry<R> getEntry() {
             return entry;
         }
-        
-        @Nonnull
+
+        @NotNull
         public abstract ImmutableList<R> getSelections();
-        
+
         public abstract void initCells();
-        
+
         public abstract void render(int mouseX, int mouseY, Rectangle rectangle, float delta);
-        
+
         public abstract void lateRender(int mouseX, int mouseY, float delta);
-        
+
         public abstract int getHeight();
-        
-        public final boolean isExpended() {
+
+        public final boolean isExpanded() {
             return (getEntry().selectionElement.getFocused() == getEntry().selectionElement.topRenderer || getEntry().selectionElement.getFocused() == getEntry().selectionElement.menu) && getEntry().getFocused() == getEntry().selectionElement && getEntry().getParent().getFocused() == getEntry();
         }
-        
+
         @Override
         public abstract List<SelectionCellElement<R>> children();
     }
-    
+
     public static class DefaultDropdownMenuElement<R> extends DropdownMenuElement<R> {
-        @Nonnull protected ImmutableList<R> selections;
-        @Nonnull protected List<SelectionCellElement<R>> cells;
-        @Nonnull protected List<SelectionCellElement<R>> currentElements;
+        @NotNull
+        protected ImmutableList<R> selections;
+        @NotNull
+        protected List<SelectionCellElement<R>> cells;
+        @NotNull
+        protected List<SelectionCellElement<R>> currentElements;
         protected String lastSearchKeyword = "";
         protected Rectangle lastRectangle;
         protected boolean scrolling;
         protected double scroll, target;
         protected long start;
         protected long duration;
-        
-        public DefaultDropdownMenuElement(@Nonnull ImmutableList<R> selections) {
+
+        public DefaultDropdownMenuElement(@NotNull ImmutableList<R> selections) {
             this.selections = selections;
             this.cells = Lists.newArrayList();
             this.currentElements = Lists.newArrayList();
         }
-        
+
         public final double clamp(double v) {
             return MathHelper.clamp(v, -SmoothScrollingSettings.CLAMP_EXTENSION, getMaxScrollPosition() + SmoothScrollingSettings.CLAMP_EXTENSION);
         }
-        
+
         public double getMaxScroll() {
             return getCellCreator().getCellHeight() * currentElements.size();
         }
-        
+
         protected double getMaxScrollPosition() {
             return Math.max(0, this.getMaxScroll() - (getHeight()));
         }
-        
+
         @Override
-        @Nonnull
+        @NotNull
         public ImmutableList<R> getSelections() {
             return selections;
         }
-        
+
         @Override
         public void initCells() {
-            for(R selection : getSelections()) {
+            for (R selection : getSelections()) {
                 cells.add(getCellCreator().create(selection));
             }
-            for(SelectionCellElement<R> cell : cells) {
+            for (SelectionCellElement<R> cell : cells) {
                 cell.entry = getEntry();
             }
             search();
         }
-        
+
         public void search() {
             currentElements.clear();
             String keyword = this.lastSearchKeyword.toLowerCase();
-            for(SelectionCellElement<R> cell : cells) {
+            for (SelectionCellElement<R> cell : cells) {
                 String key = cell.getSearchKey();
                 if (key == null || key.toLowerCase().contains(keyword))
                     currentElements.add(cell);
@@ -295,15 +304,15 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             }
             scrollTo(0, false);
         }
-        
+
         protected int editDistance(String s1, String s2) {
             s1 = s1.toLowerCase();
             s2 = s2.toLowerCase();
-            
+
             int[] costs = new int[s2.length() + 1];
-            for(int i = 0; i <= s1.length(); i++) {
+            for (int i = 0; i <= s1.length(); i++) {
                 int lastValue = i;
-                for(int j = 0; j <= s2.length(); j++) {
+                for (int j = 0; j <= s2.length(); j++) {
                     if (i == 0)
                         costs[j] = j;
                     else {
@@ -321,7 +330,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             }
             return costs[s2.length()];
         }
-        
+
         protected double similarity(String s1, String s2) {
             String longer = s1, shorter = s2;
             if (s1.length() < s2.length()) { // longer should always have greater length
@@ -334,7 +343,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             }
             return (longerLength - editDistance(longer, shorter)) / (double) longerLength;
         }
-        
+
         @Override
         public void render(int mouseX, int mouseY, Rectangle rectangle, float delta) {
             if (!getEntry().selectionElement.topRenderer.getSearchTerm().equals(lastSearchKeyword)) {
@@ -345,7 +354,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             lastRectangle = rectangle.clone();
             lastRectangle.translate(0, -1);
         }
-        
+
         private void updatePosition(float delta) {
             target = clamp(target);
             if (target < 0) {
@@ -358,7 +367,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             else
                 scroll = target;
         }
-        
+
         @Override
         public void lateRender(int mouseX, int mouseY, float delta) {
             int last10Height = getHeight();
@@ -367,10 +376,10 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             fill(lastRectangle.x + 1, lastRectangle.y + lastRectangle.height + 1, lastRectangle.x + cWidth - 1, lastRectangle.y + lastRectangle.height + last10Height, -16777216);
             RenderSystem.pushMatrix();
             RenderSystem.translatef(0, 0, 300f);
-            
+
             ScissorsHandler.INSTANCE.scissor(new Rectangle(lastRectangle.x, lastRectangle.y + lastRectangle.height + 1, cWidth - 6, last10Height - 1));
             double yy = lastRectangle.y + lastRectangle.height - scroll;
-            for(SelectionCellElement<R> cell : currentElements) {
+            for (SelectionCellElement<R> cell : currentElements) {
                 if (yy + getCellCreator().getCellHeight() >= lastRectangle.y + lastRectangle.height && yy <= lastRectangle.y + lastRectangle.height + last10Height + 1)
                     cell.render(mouseX, mouseY, lastRectangle.x, (int) yy, getMaxScrollPosition() > 6 ? getCellCreator().getCellWidth() - 6 : getCellCreator().getCellWidth(), getCellCreator().getCellHeight(), delta);
                 else
@@ -378,13 +387,13 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                 yy += getCellCreator().getCellHeight();
             }
             ScissorsHandler.INSTANCE.removeLastScissor();
-            
+
             if (currentElements.isEmpty()) {
                 TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
                 String s = I18n.translate("text.cloth-config.dropdown.value.unknown");
                 textRenderer.drawWithShadow(s, lastRectangle.x + getCellCreator().getCellWidth() / 2 - textRenderer.getStringWidth(s) / 2, lastRectangle.y + lastRectangle.height + 3, -1);
             }
-            
+
             if (getMaxScrollPosition() > 6) {
                 RenderSystem.disableTexture();
                 int scrollbarPositionMinX = lastRectangle.x + getCellCreator().getCellWidth() - 6;
@@ -394,13 +403,13 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                 height -= Math.min((scroll < 0 ? (int) -scroll : scroll > getMaxScrollPosition() ? (int) scroll - getMaxScrollPosition() : 0), height * .95);
                 height = Math.max(10, height);
                 int minY = (int) Math.min(Math.max((int) scroll * (last10Height - height) / getMaxScrollPosition() + (lastRectangle.y + lastRectangle.height + 1), (lastRectangle.y + lastRectangle.height + 1)), (lastRectangle.y + lastRectangle.height + 1 + last10Height) - height);
-                
+
                 int bottomc = new Rectangle(scrollbarPositionMinX, minY, scrollbarPositionMaxX - scrollbarPositionMinX, height).contains(PointHelper.fromMouse()) ? 168 : 128;
                 int topc = new Rectangle(scrollbarPositionMinX, minY, scrollbarPositionMaxX - scrollbarPositionMinX, height).contains(PointHelper.fromMouse()) ? 222 : 172;
-                
+
                 Tessellator tessellator = Tessellator.getInstance();
                 BufferBuilder buffer = tessellator.getBuffer();
-                
+
                 // Bottom
                 buffer.begin(7, VertexFormats.POSITION_TEXTURE_COLOR);
                 buffer.vertex(scrollbarPositionMinX, minY + height, 0.0D).texture(0, 1).color(bottomc, bottomc, bottomc, 255).next();
@@ -408,7 +417,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                 buffer.vertex(scrollbarPositionMaxX, minY, 0.0D).texture(1, 0).color(bottomc, bottomc, bottomc, 255).next();
                 buffer.vertex(scrollbarPositionMinX, minY, 0.0D).texture(0, 0).color(bottomc, bottomc, bottomc, 255).next();
                 tessellator.draw();
-                
+
                 // Top
                 buffer.begin(7, VertexFormats.POSITION_TEXTURE_COLOR);
                 buffer.vertex(scrollbarPositionMinX, (minY + height - 1), 0.0D).texture(0, 1).color(topc, topc, topc, 255).next();
@@ -421,20 +430,20 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             RenderSystem.translatef(0, 0, -300f);
             RenderSystem.popMatrix();
         }
-        
+
         @Override
         public int getHeight() {
             return Math.max(Math.min(getCellCreator().getDropBoxMaxHeight(), (int) getMaxScroll()), 14);
         }
-        
+
         @Override
         public boolean isMouseOver(double mouseX, double mouseY) {
-            return isExpended() && mouseX >= lastRectangle.x && mouseX <= lastRectangle.x + getCellCreator().getCellWidth() && mouseY >= lastRectangle.y + lastRectangle.height && mouseY <= lastRectangle.y + lastRectangle.height + getHeight() + 1;
+            return isExpanded() && mouseX >= lastRectangle.x && mouseX <= lastRectangle.x + getCellCreator().getCellWidth() && mouseY >= lastRectangle.y + lastRectangle.height && mouseY <= lastRectangle.y + lastRectangle.height + getHeight() + 1;
         }
-        
+
         @Override
         public boolean mouseDragged(double double_1, double double_2, int int_1, double double_3, double double_4) {
-            if (!isExpended())
+            if (!isExpanded())
                 return false;
             if (int_1 == 0 && this.scrolling) {
                 if (double_2 < (double) lastRectangle.y + lastRectangle.height) {
@@ -453,7 +462,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             }
             return false;
         }
-        
+
         @Override
         public boolean mouseScrolled(double mouseX, double mouseY, double double_3) {
             if (isMouseOver(mouseX, mouseY)) {
@@ -462,101 +471,103 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             }
             return false;
         }
-        
+
         protected void updateScrollingState(double double_1, double double_2, int int_1) {
-            this.scrolling = isExpended() && lastRectangle != null && int_1 == 0 && double_1 >= (double) lastRectangle.x + getCellCreator().getCellWidth() - 6 && double_1 < (double) (lastRectangle.x + getCellCreator().getCellWidth());
+            this.scrolling = isExpanded() && lastRectangle != null && int_1 == 0 && double_1 >= (double) lastRectangle.x + getCellCreator().getCellWidth() - 6 && double_1 < (double) (lastRectangle.x + getCellCreator().getCellWidth());
         }
-        
+
         @Override
         public boolean mouseClicked(double double_1, double double_2, int int_1) {
-            if (!isExpended())
+            if (!isExpanded())
                 return false;
             updateScrollingState(double_1, double_2, int_1);
             return super.mouseClicked(double_1, double_2, int_1) || scrolling;
         }
-        
+
         public void offset(double value, boolean animated) {
             scrollTo(target + value, animated);
         }
-        
+
         public void scrollTo(double value, boolean animated) {
             scrollTo(value, animated, ClothConfigInitializer.getScrollDuration());
         }
-        
+
         public void scrollTo(double value, boolean animated, long duration) {
             target = clamp(value);
-            
+
             if (animated) {
                 start = System.currentTimeMillis();
                 this.duration = duration;
             } else
                 scroll = target;
         }
-        
+
         @Override
         public List<SelectionCellElement<R>> children() {
             return currentElements;
         }
     }
-    
+
     public static abstract class SelectionCellCreator<R> {
         public abstract SelectionCellElement<R> create(R selection);
-        
+
         public abstract int getCellHeight();
-        
+
         public abstract int getDropBoxMaxHeight();
-        
+
         public int getCellWidth() {
             return 132;
         }
     }
-    
+
     public static class DefaultSelectionCellCreator<R> extends SelectionCellCreator<R> {
         protected Function<R, String> toStringFunction;
-        
+
         public DefaultSelectionCellCreator(Function<R, String> toStringFunction) {
             this.toStringFunction = toStringFunction;
         }
-        
+
         public DefaultSelectionCellCreator() {
             this(Object::toString);
         }
-        
+
         @Override
         public SelectionCellElement<R> create(R selection) {
             return new DefaultSelectionCellElement<>(selection, toStringFunction);
         }
-        
+
         @Override
         public int getCellHeight() {
             return 14;
         }
-        
+
         @Override
         public int getDropBoxMaxHeight() {
             return getCellHeight() * 7;
         }
     }
-    
+
     public static abstract class SelectionCellElement<R> extends AbstractParentElement {
-        @Deprecated @Nonnull private DropdownBoxEntry<R> entry;
-        
-        @Nonnull
+        @Deprecated
+        @NotNull
+        private DropdownBoxEntry<R> entry;
+
+        @NotNull
         public final DropdownBoxEntry<R> getEntry() {
             return entry;
         }
-        
+
         public abstract void render(int mouseX, int mouseY, int x, int y, int width, int height, float delta);
-        
+
         public abstract void dontRender(float delta);
-        
+
         @Nullable
         public abstract String getSearchKey();
-        
+
         @Nullable
         public abstract R getSelection();
     }
-    
+
     public static class DefaultSelectionCellElement<R> extends SelectionCellElement<R> {
         protected R r;
         protected int x;
@@ -565,12 +576,12 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         protected int height;
         protected boolean rendering;
         protected Function<R, String> toStringFunction;
-        
+
         public DefaultSelectionCellElement(R r, Function<R, String> toStringFunction) {
             this.r = r;
             this.toStringFunction = toStringFunction;
         }
-        
+
         @Override
         public void render(int mouseX, int mouseY, int x, int y, int width, int height, float delta) {
             rendering = true;
@@ -583,29 +594,29 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                 fill(x + 1, y + 1, x + width - 1, y + height - 1, -15132391);
             MinecraftClient.getInstance().textRenderer.drawWithShadow(toStringFunction.apply(r), x + 6, y + 3, b ? 16777215 : 8947848);
         }
-        
+
         @Override
         public void dontRender(float delta) {
             rendering = false;
         }
-        
+
         @Nullable
         @Override
         public String getSearchKey() {
             return toStringFunction.apply(r);
         }
-        
+
         @Nullable
         @Override
         public R getSelection() {
             return r;
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.emptyList();
         }
-        
+
         @Override
         public boolean mouseClicked(double mouseX, double mouseY, int int_1) {
             boolean b = rendering && mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
@@ -618,37 +629,38 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             return false;
         }
     }
-    
+
     public static abstract class SelectionTopCellElement<R> extends AbstractParentElement {
-        @Deprecated private DropdownBoxEntry<R> entry;
-        
+        @Deprecated
+        private DropdownBoxEntry<R> entry;
+
         public abstract R getValue();
-        
+
         public abstract void setValue(R value);
-        
+
         public abstract String getSearchTerm();
-        
+
         public abstract Optional<String> getError();
-        
+
         public final Optional<String> getConfigError() {
             return entry.getConfigError();
         }
-        
+
         public DropdownBoxEntry<R> getParent() {
             return entry;
         }
-        
+
         public final boolean hasConfigError() {
             return getConfigError().isPresent();
         }
-        
+
         public final int getPreferredTextColor() {
             return getConfigError().isPresent() ? 16733525 : 16777215;
         }
-        
+
         public void selectFirstRecommendation() {
             List<SelectionCellElement<R>> children = getParent().selectionElement.menu.children();
-            for(SelectionCellElement<R> child : children) {
+            for (SelectionCellElement<R> child : children) {
                 if (child.getSelection() != null) {
                     setValue(child.getSelection());
                     getParent().selectionElement.setFocused(null);
@@ -656,16 +668,16 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                 }
             }
         }
-        
+
         public abstract void render(int mouseX, int mouseY, int x, int y, int width, int height, float delta);
     }
-    
+
     public static class DefaultSelectionTopCellElement<R> extends SelectionTopCellElement<R> {
         protected TextFieldWidget textFieldWidget;
         protected Function<String, R> toObjectFunction;
         protected Function<R, String> toStringFunction;
         protected R value;
-        
+
         public DefaultSelectionTopCellElement(R value, Function<String, R> toObjectFunction, Function<R, String> toStringFunction) {
             this.value = Objects.requireNonNull(value);
             this.toObjectFunction = Objects.requireNonNull(toObjectFunction);
@@ -678,7 +690,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                     super.render(int_1, int_2, float_1);
                     setFocused(f);
                 }
-                
+
                 @Override
                 public boolean keyPressed(int int_1, int int_2, int int_3) {
                     if (int_1 == 257 || int_1 == 335) {
@@ -696,7 +708,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
                     getParent().getScreen().setEdited(true, getParent().isRequiresRestart());
             });
         }
-        
+
         @Override
         public void render(int mouseX, int mouseY, int x, int y, int width, int height, float delta) {
             textFieldWidget.x = x + 4;
@@ -706,32 +718,32 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             textFieldWidget.setEditableColor(getPreferredTextColor());
             textFieldWidget.render(mouseX, mouseY, delta);
         }
-        
+
         @Override
         public R getValue() {
             if (hasConfigError())
                 return value;
             return toObjectFunction.apply(textFieldWidget.getText());
         }
-        
+
         @Override
         public void setValue(R value) {
             textFieldWidget.setText(toStringFunction.apply(value));
             textFieldWidget.setCursor(0);
         }
-        
+
         @Override
         public String getSearchTerm() {
             return textFieldWidget.getText();
         }
-        
+
         @Override
         public Optional<String> getError() {
             if (toObjectFunction.apply(textFieldWidget.getText()) != null)
                 return Optional.empty();
             return Optional.of("Invalid Value!");
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(textFieldWidget);

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
@@ -19,19 +19,19 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
     private Function<Float, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
+    public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
 
     @Deprecated
-    public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey, boolean requiresRestart) {
+    public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, floatListListEntry -> new FloatListCell(0, floatListListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Float.MAX_VALUE;
         this.maximum = Float.MAX_VALUE;
         for (float f : value)
             cells.add(new FloatListCell(f, this));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
 
     public Function<Float, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
@@ -25,7 +25,11 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
 
     @Deprecated
     public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, floatListListEntry -> new FloatListCell(0, floatListListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, tooltipSupplier, defaultValue, floatListListEntry -> new FloatListCell(0, floatListListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         this.minimum = -Float.MAX_VALUE;
         this.maximum = Float.MAX_VALUE;
         for (float f : value)

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
@@ -13,72 +13,77 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.FloatListCell> {
-    
+public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.FloatListCell, FloatListListEntry> {
+
     private float minimum, maximum;
     private Function<Float, Optional<String>> cellErrorSupplier;
-    
+
     @Deprecated
     public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey) {
         this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
-    
+
     @Deprecated
     public FloatListListEntry(String fieldName, List<Float> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Float>> saveConsumer, Supplier<List<Float>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new FloatListCell(0, (FloatListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        super(fieldName, tooltipSupplier, defaultValue, floatListListEntry -> new FloatListCell(0, floatListListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Float.MAX_VALUE;
         this.maximum = Float.MAX_VALUE;
-        for(float f : value)
+        for (float f : value)
             cells.add(new FloatListCell(f, this));
         this.widgets.addAll(cells);
         expended = defaultExpended;
     }
-    
+
     public Function<Float, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public void setCellErrorSupplier(Function<Float, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
     }
-    
+
     @Override
     public List<Float> getValue() {
         return cells.stream().map(FloatListCell::getValue).collect(Collectors.toList());
     }
-    
+
     public FloatListListEntry setMaximum(float maximum) {
         this.maximum = maximum;
         return this;
     }
-    
+
     public FloatListListEntry setMinimum(float minimum) {
         this.minimum = minimum;
         return this;
     }
-    
+
+    @Override
+    public FloatListListEntry self() {
+        return this;
+    }
+
     @Override
     protected FloatListCell getFromValue(Float value) {
         return new FloatListCell(value, this);
     }
-    
+
     public static class FloatListCell extends BaseListCell {
-        
+
         private Function<String, String> stripCharacters = s -> {
             StringBuilder stringBuilder_1 = new StringBuilder();
             char[] var2 = s.toCharArray();
             int var3 = var2.length;
-            
-            for(int var4 = 0; var4 < var3; ++var4)
+
+            for (int var4 = 0; var4 < var3; ++var4)
                 if (Character.isDigit(var2[var4]) || var2[var4] == '-' || var2[var4] == '.')
                     stringBuilder_1.append(var2[var4]);
-            
+
             return stringBuilder_1.toString();
         };
         private TextFieldWidget widget;
         private boolean isSelected;
         private FloatListListEntry listListEntry;
-        
+
         public FloatListCell(float value, FloatListListEntry listListEntry) {
             this.listListEntry = listListEntry;
             this.setErrorSupplier(() -> listListEntry.cellErrorSupplier == null ? Optional.empty() : listListEntry.getCellErrorSupplier().apply(getValue()));
@@ -91,7 +96,7 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
                     super.render(int_1, int_2, float_1);
                     setFocused(f);
                 }
-                
+
                 @Override
                 public void write(String string_1) {
                     super.write(stripCharacters.apply(string_1));
@@ -105,7 +110,7 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
                     listListEntry.getScreen().setEdited(true, listListEntry.isRequiresRestart());
             });
         }
-        
+
         public float getValue() {
             try {
                 return Float.valueOf(widget.getText());
@@ -113,7 +118,7 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
                 return 0f;
             }
         }
-        
+
         @Override
         public Optional<String> getError() {
             try {
@@ -127,12 +132,12 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
             }
             return Optional.empty();
         }
-        
+
         @Override
         public int getCellHeight() {
             return 20;
         }
-        
+
         @Override
         public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
             widget.setWidth(entryWidth - 12);
@@ -144,12 +149,12 @@ public class FloatListListEntry extends BaseListEntry<Float, FloatListListEntry.
             if (isSelected && listListEntry.isEditable())
                 fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(widget);
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatListListEntry.java
@@ -1,21 +1,17 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class FloatListListEntry extends AbstractListListEntry<Float, FloatListListEntry.FloatListCell, FloatListListEntry> {
+public class FloatListListEntry extends AbstractTextFieldListListEntry<Float, FloatListListEntry.FloatListCell, FloatListListEntry> {
 
     private float minimum, maximum;
 
@@ -46,11 +42,6 @@ public class FloatListListEntry extends AbstractListListEntry<Float, FloatListLi
         this.maximum = Float.POSITIVE_INFINITY;
     }
 
-    @Override
-    public List<Float> getValue() {
-        return cells.stream().map(FloatListCell::getValue).collect(Collectors.toList());
-    }
-
     public FloatListListEntry setMaximum(float maximum) {
         this.maximum = maximum;
         return this;
@@ -66,34 +57,24 @@ public class FloatListListEntry extends AbstractListListEntry<Float, FloatListLi
         return this;
     }
 
-    @Override
-    protected FloatListCell getFromValue(Float value) {
-        return new FloatListCell(value, this);
-    }
-
-    public static class FloatListCell extends AbstractListListEntry.AbstractListCell<Float, FloatListCell, FloatListListEntry> {
-
-        private TextFieldWidget widget;
+    public static class FloatListCell extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<Float, FloatListCell, FloatListListEntry> {
 
         public FloatListCell(Float value, FloatListListEntry listListEntry) {
             super(value, listListEntry);
+        }
 
+        @Nullable
+        @Override
+        protected Float substituteDefault(@Nullable Float value) {
             if (value == null)
-                value = 0f;
-            Float finalValue = value;
+                return 0f;
+            else
+                return value;
+        }
 
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(fn -> fn.apply(this.getValue())));
-            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            widget.setTextPredicate(s -> s.chars().allMatch(c -> Character.isDigit(c) || c == '-' || c == '.'));
-            widget.setMaxLength(Integer.MAX_VALUE);
-            widget.setHasBorder(false);
-            widget.setText(value.toString());
-            widget.setChangedListener(s -> {
-                widget.setEditableColor(getPreferredTextColor());
-                if (!Objects.equals(s, finalValue.toString())) {
-                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
-                }
-            });
+        @Override
+        protected boolean isValidText(@NotNull String text) {
+            return text.chars().allMatch(c -> Character.isDigit(c) || c == '-' || c == '.');
         }
 
         public Float getValue() {
@@ -117,28 +98,5 @@ public class FloatListListEntry extends AbstractListListEntry<Float, FloatListLi
             }
             return Optional.empty();
         }
-
-        @Override
-        public int getCellHeight() {
-            return 20;
-        }
-
-        @Override
-        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-            widget.setWidth(entryWidth - 12);
-            widget.x = x;
-            widget.y = y + 1;
-            widget.setEditable(listListEntry.isEditable());
-            widget.render(mouseX, mouseY, delta);
-            if (isSelected && listListEntry.isEditable())
-                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
-        }
-
-        @Override
-        public List<? extends Element> children() {
-            return Collections.singletonList(widget);
-        }
-
     }
-
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
@@ -1,21 +1,17 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class IntegerListListEntry extends AbstractListListEntry<Integer, IntegerListListEntry.IntegerListCell, IntegerListListEntry> {
+public class IntegerListListEntry extends AbstractTextFieldListListEntry<Integer, IntegerListListEntry.IntegerListCell, IntegerListListEntry> {
 
     private int minimum, maximum;
 
@@ -46,11 +42,6 @@ public class IntegerListListEntry extends AbstractListListEntry<Integer, Integer
         this.maximum = Integer.MAX_VALUE;
     }
 
-    @Override
-    public List<Integer> getValue() {
-        return cells.stream().map(IntegerListCell::getValue).collect(Collectors.toList());
-    }
-
     public IntegerListListEntry setMaximum(int maximum) {
         this.maximum = maximum;
         return this;
@@ -66,34 +57,24 @@ public class IntegerListListEntry extends AbstractListListEntry<Integer, Integer
         return this;
     }
 
-    @Override
-    protected IntegerListCell getFromValue(Integer value) {
-        return new IntegerListCell(value, this);
-    }
-
-    public static class IntegerListCell extends AbstractListListEntry.AbstractListCell<Integer, IntegerListCell, IntegerListListEntry> {
-
-        private TextFieldWidget widget;
+    public static class IntegerListCell extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<Integer, IntegerListCell, IntegerListListEntry> {
 
         public IntegerListCell(Integer value, IntegerListListEntry listListEntry) {
             super(value, listListEntry);
+        }
 
+        @Nullable
+        @Override
+        protected Integer substituteDefault(@Nullable Integer value) {
             if (value == null)
-                value = 0;
-            Integer finalValue = value;
+                return 0;
+            else
+                return value;
+        }
 
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(fn -> fn.apply(this.getValue())));
-            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            widget.setTextPredicate(s -> s.chars().allMatch(c -> Character.isDigit(c) || c == '-'));
-            widget.setMaxLength(Integer.MAX_VALUE);
-            widget.setHasBorder(false);
-            widget.setText(value.toString());
-            widget.setChangedListener(s -> {
-                widget.setEditableColor(getPreferredTextColor());
-                if (!Objects.equals(s, finalValue.toString())) {
-                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
-                }
-            });
+        @Override
+        protected boolean isValidText(@NotNull String text) {
+            return text.chars().allMatch(c -> Character.isDigit(c) || c == '-');
         }
 
         public Integer getValue() {
@@ -117,28 +98,6 @@ public class IntegerListListEntry extends AbstractListListEntry<Integer, Integer
             }
             return Optional.empty();
         }
-
-        @Override
-        public int getCellHeight() {
-            return 20;
-        }
-
-        @Override
-        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-            widget.setWidth(entryWidth - 12);
-            widget.x = x;
-            widget.y = y + 1;
-            widget.setEditable(listListEntry.isEditable());
-            widget.render(mouseX, mouseY, delta);
-            if (isSelected && listListEntry.isEditable())
-                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
-        }
-
-        @Override
-        public List<? extends Element> children() {
-            return Collections.singletonList(widget);
-        }
-
     }
 
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
@@ -25,7 +25,11 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
 
     @Deprecated
     public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, integerListListEntry -> new IntegerListCell(0, integerListListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, tooltipSupplier, defaultValue, integerListListEntry -> new IntegerListCell(0, integerListListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         this.minimum = -Integer.MAX_VALUE;
         this.maximum = Integer.MAX_VALUE;
         for (int integer : value)

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
@@ -19,19 +19,19 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
     private Function<Integer, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
+    public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
 
     @Deprecated
-    public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey, boolean requiresRestart) {
+    public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, integerListListEntry -> new IntegerListCell(0, integerListListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Integer.MAX_VALUE;
         this.maximum = Integer.MAX_VALUE;
         for (int integer : value)
             cells.add(new IntegerListCell(integer, this));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
 
     public Function<Integer, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerListListEntry.java
@@ -13,72 +13,77 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListListEntry.IntegerListCell> {
-    
+public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListListEntry.IntegerListCell, IntegerListListEntry> {
+
     private int minimum, maximum;
     private Function<Integer, Optional<String>> cellErrorSupplier;
-    
+
     @Deprecated
     public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey) {
         this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
-    
+
     @Deprecated
     public IntegerListListEntry(String fieldName, List<Integer> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new IntegerListCell(0, (IntegerListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        super(fieldName, tooltipSupplier, defaultValue, integerListListEntry -> new IntegerListCell(0, integerListListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Integer.MAX_VALUE;
         this.maximum = Integer.MAX_VALUE;
-        for(int integer : value)
+        for (int integer : value)
             cells.add(new IntegerListCell(integer, this));
         this.widgets.addAll(cells);
         expended = defaultExpended;
     }
-    
+
     public Function<Integer, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public void setCellErrorSupplier(Function<Integer, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
     }
-    
+
     @Override
     public List<Integer> getValue() {
         return cells.stream().map(IntegerListCell::getValue).collect(Collectors.toList());
     }
-    
+
     public IntegerListListEntry setMaximum(int maximum) {
         this.maximum = maximum;
         return this;
     }
-    
+
     public IntegerListListEntry setMinimum(int minimum) {
         this.minimum = minimum;
         return this;
     }
-    
+
+    @Override
+    public IntegerListListEntry self() {
+        return this;
+    }
+
     @Override
     protected IntegerListCell getFromValue(Integer value) {
         return new IntegerListCell(value, this);
     }
-    
+
     public static class IntegerListCell extends BaseListCell {
-        
+
         private Function<String, String> stripCharacters = s -> {
             StringBuilder stringBuilder_1 = new StringBuilder();
             char[] var2 = s.toCharArray();
             int var3 = var2.length;
-            
-            for(int var4 = 0; var4 < var3; ++var4)
+
+            for (int var4 = 0; var4 < var3; ++var4)
                 if (Character.isDigit(var2[var4]) || var2[var4] == '-')
                     stringBuilder_1.append(var2[var4]);
-            
+
             return stringBuilder_1.toString();
         };
         private TextFieldWidget widget;
         private boolean isSelected;
         private IntegerListListEntry listListEntry;
-        
+
         public IntegerListCell(int value, IntegerListListEntry listListEntry) {
             this.listListEntry = listListEntry;
             this.setErrorSupplier(() -> listListEntry.cellErrorSupplier == null ? Optional.empty() : listListEntry.getCellErrorSupplier().apply(getValue()));
@@ -91,7 +96,7 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
                     super.render(int_1, int_2, float_1);
                     setFocused(f);
                 }
-                
+
                 @Override
                 public void write(String string_1) {
                     super.write(stripCharacters.apply(string_1));
@@ -105,7 +110,7 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
                     listListEntry.getScreen().setEdited(true, listListEntry.isRequiresRestart());
             });
         }
-        
+
         public int getValue() {
             try {
                 return Integer.valueOf(widget.getText());
@@ -113,7 +118,7 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
                 return 0;
             }
         }
-        
+
         @Override
         public Optional<String> getError() {
             try {
@@ -127,12 +132,12 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
             }
             return Optional.empty();
         }
-        
+
         @Override
         public int getCellHeight() {
             return 20;
         }
-        
+
         @Override
         public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
             widget.setWidth(entryWidth - 12);
@@ -144,12 +149,12 @@ public class IntegerListListEntry extends BaseListEntry<Integer, IntegerListList
             if (isSelected && listListEntry.isEditable())
                 fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(widget);
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
@@ -1,21 +1,17 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.resource.language.I18n;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class LongListListEntry extends AbstractListListEntry<Long, LongListListEntry.LongListCell, LongListListEntry> {
+public class LongListListEntry extends AbstractTextFieldListListEntry<Long, LongListListEntry.LongListCell, LongListListEntry> {
 
     private long minimum, maximum;
 
@@ -35,11 +31,6 @@ public class LongListListEntry extends AbstractListListEntry<Long, LongListListE
         this.maximum = Long.MAX_VALUE;
     }
 
-    @Override
-    public List<Long> getValue() {
-        return cells.stream().map(LongListCell::getValue).collect(Collectors.toList());
-    }
-
     public LongListListEntry setMaximum(long maximum) {
         this.maximum = maximum;
         return this;
@@ -55,34 +46,24 @@ public class LongListListEntry extends AbstractListListEntry<Long, LongListListE
         return this;
     }
 
-    @Override
-    protected LongListCell getFromValue(Long value) {
-        return new LongListCell(value, this);
-    }
-
-    public static class LongListCell extends AbstractListListEntry.AbstractListCell<Long, LongListCell, LongListListEntry> {
-
-        private TextFieldWidget widget;
+    public static class LongListCell extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<Long, LongListCell, LongListListEntry> {
 
         public LongListCell(Long value, LongListListEntry listListEntry) {
             super(value, listListEntry);
+        }
 
+        @Nullable
+        @Override
+        protected Long substituteDefault(@Nullable Long value) {
             if (value == null)
-                value = 0L;
-            Long finalValue = value;
+                return 0L;
+            else
+                return value;
+        }
 
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(fn -> fn.apply(this.getValue())));
-            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            widget.setTextPredicate(s -> s.chars().allMatch(c -> Character.isDigit(c) || c == '-'));
-            widget.setMaxLength(Integer.MAX_VALUE);
-            widget.setHasBorder(false);
-            widget.setText(value.toString());
-            widget.setChangedListener(s -> {
-                widget.setEditableColor(getPreferredTextColor());
-                if (!Objects.equals(s, finalValue.toString())) {
-                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
-                }
-            });
+        @Override
+        protected boolean isValidText(@NotNull String text) {
+            return text.chars().allMatch(c -> Character.isDigit(c) || c == '-');
         }
 
         public Long getValue() {
@@ -106,28 +87,6 @@ public class LongListListEntry extends AbstractListListEntry<Long, LongListListE
             }
             return Optional.empty();
         }
-
-        @Override
-        public int getCellHeight() {
-            return 20;
-        }
-
-        @Override
-        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-            widget.setWidth(entryWidth - 12);
-            widget.x = x;
-            widget.y = y + 1;
-            widget.setEditable(listListEntry.isEditable());
-            widget.render(mouseX, mouseY, delta);
-            if (isSelected && listListEntry.isEditable())
-                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
-        }
-
-        @Override
-        public List<? extends Element> children() {
-            return Collections.singletonList(widget);
-        }
-
     }
 
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
@@ -25,7 +25,11 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
 
     @Deprecated
     public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new LongListCell(0, (LongListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new LongListCell(0, baseListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         this.minimum = -Long.MAX_VALUE;
         this.maximum = Long.MAX_VALUE;
         for (long l : value)

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
@@ -13,72 +13,77 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.LongListCell> {
-    
+public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.LongListCell, LongListListEntry> {
+
     private long minimum, maximum;
     private Function<Long, Optional<String>> cellErrorSupplier;
-    
+
     @Deprecated
     public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey) {
         this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
-    
+
     @Deprecated
     public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new LongListCell(0, (LongListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Long.MAX_VALUE;
         this.maximum = Long.MAX_VALUE;
-        for(long l : value)
+        for (long l : value)
             cells.add(new LongListCell(l, this));
         this.widgets.addAll(cells);
         expended = defaultExpended;
     }
-    
+
     public Function<Long, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public void setCellErrorSupplier(Function<Long, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
     }
-    
+
     @Override
     public List<Long> getValue() {
         return cells.stream().map(LongListCell::getValue).collect(Collectors.toList());
     }
-    
+
     public LongListListEntry setMaximum(long maximum) {
         this.maximum = maximum;
         return this;
     }
-    
+
     public LongListListEntry setMinimum(long minimum) {
         this.minimum = minimum;
         return this;
     }
-    
+
+    @Override
+    public LongListListEntry self() {
+        return this;
+    }
+
     @Override
     protected LongListCell getFromValue(Long value) {
         return new LongListCell(value, this);
     }
-    
+
     public static class LongListCell extends BaseListCell {
-        
+
         private Function<String, String> stripCharacters = s -> {
             StringBuilder stringBuilder_1 = new StringBuilder();
             char[] var2 = s.toCharArray();
             int var3 = var2.length;
-            
-            for(int var4 = 0; var4 < var3; ++var4)
+
+            for (int var4 = 0; var4 < var3; ++var4)
                 if (Character.isDigit(var2[var4]) || var2[var4] == '-')
                     stringBuilder_1.append(var2[var4]);
-            
+
             return stringBuilder_1.toString();
         };
         private TextFieldWidget widget;
         private boolean isSelected;
         private LongListListEntry listListEntry;
-        
+
         public LongListCell(long value, LongListListEntry listListEntry) {
             this.listListEntry = listListEntry;
             this.setErrorSupplier(() -> listListEntry.cellErrorSupplier == null ? Optional.empty() : listListEntry.getCellErrorSupplier().apply(getValue()));
@@ -91,7 +96,7 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
                     super.render(int_1, int_2, float_1);
                     setFocused(f);
                 }
-                
+
                 @Override
                 public void write(String string_1) {
                     super.write(stripCharacters.apply(string_1));
@@ -105,7 +110,7 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
                     listListEntry.getScreen().setEdited(true, listListEntry.isRequiresRestart());
             });
         }
-        
+
         public long getValue() {
             try {
                 return Long.valueOf(widget.getText());
@@ -113,7 +118,7 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
                 return 0;
             }
         }
-        
+
         @Override
         public Optional<String> getError() {
             try {
@@ -127,12 +132,12 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
             }
             return Optional.empty();
         }
-        
+
         @Override
         public int getCellHeight() {
             return 20;
         }
-        
+
         @Override
         public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
             widget.setWidth(entryWidth - 12);
@@ -144,12 +149,12 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
             if (isSelected && listListEntry.isEditable())
                 fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(widget);
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongListListEntry.java
@@ -19,19 +19,19 @@ public class LongListListEntry extends BaseListEntry<Long, LongListListEntry.Lon
     private Function<Long, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
+    public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
 
     @Deprecated
-    public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey, boolean requiresRestart) {
+    public LongListListEntry(String fieldName, List<Long> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new LongListCell(0, (LongListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
         this.minimum = -Long.MAX_VALUE;
         this.maximum = Long.MAX_VALUE;
         for (long l : value)
             cells.add(new LongListCell(l, this));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
 
     public Function<Long, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
@@ -1,0 +1,152 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.systems.RenderSystem;
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import me.shedaniel.math.api.Rectangle;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.render.DiffuseLighting;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MultiElementListEntry<T> extends TooltipListEntry<T> {
+
+    private static final Identifier CONFIG_TEX = new Identifier("cloth-config2", "textures/gui/cloth_config.png");
+    private final T object;
+    private String categoryName;
+    private List<AbstractConfigListEntry<?>> entries;
+    private MultiElementListEntry<T>.CategoryLabelWidget widget;
+    private List<Element> children;
+    private boolean expanded;
+
+    @ApiStatus.Internal
+    public MultiElementListEntry(String categoryName, T object, List<AbstractConfigListEntry<?>> entries, boolean defaultExpanded) {
+        super(categoryName, null);
+        this.categoryName = categoryName;
+        this.object = object;
+        this.entries = entries;
+        this.expanded = defaultExpanded;
+        this.widget = new MultiElementListEntry<T>.CategoryLabelWidget();
+        this.children = Lists.newArrayList(widget);
+        this.children.addAll(entries);
+    }
+
+    @Override
+    public boolean isRequiresRestart() {
+        for (AbstractConfigListEntry entry : entries)
+            if (entry.isRequiresRestart())
+                return true;
+        return false;
+    }
+
+    @Override
+    public void setRequiresRestart(boolean requiresRestart) {
+
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    @Override
+    public T getValue() {
+        return object;
+    }
+
+    @Override
+    public Optional<T> getDefaultValue() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
+        super.render(index, y, x, entryWidth, entryHeight, mouseX, mouseY, isSelected, delta);
+        widget.rectangle.x = x - 19;
+        widget.rectangle.y = y;
+        widget.rectangle.width = entryWidth + 19;
+        widget.rectangle.height = 24;
+        MinecraftClient.getInstance().getTextureManager().bindTexture(CONFIG_TEX);
+        DiffuseLighting.disable();
+        RenderSystem.color4f(1, 1, 1, 1);
+        blit(x - 15, y + 4, 24, (widget.rectangle.contains(mouseX, mouseY) ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
+        MinecraftClient.getInstance().textRenderer.drawWithShadow(I18n.translate(categoryName), x, y + 5, widget.rectangle.contains(mouseX, mouseY) ? 0xffe6fe16 : -1);
+        for (AbstractConfigListEntry<?> entry : entries) {
+            entry.setParent(getParent());
+            entry.setScreen(getScreen());
+        }
+        if (expanded) {
+            int yy = y + 24;
+            for (AbstractConfigListEntry<?> entry : entries) {
+                entry.render(-1, yy, x + 14, entryWidth - 14, entry.getItemHeight(), mouseX, mouseY, isSelected, delta);
+                yy += entry.getItemHeight();
+            }
+        }
+    }
+
+    @Override
+    public boolean isMouseInside(int mouseX, int mouseY, int x, int y, int entryWidth, int entryHeight) {
+        widget.rectangle.x = x - 15;
+        widget.rectangle.y = y;
+        widget.rectangle.width = entryWidth + 15;
+        widget.rectangle.height = 24;
+        return widget.rectangle.contains(mouseX, mouseY) && getParent().isMouseOver(mouseX, mouseY);
+    }
+
+    @Override
+    public int getItemHeight() {
+        if (expanded) {
+            int i = 24;
+            for (AbstractConfigListEntry<?> entry : entries)
+                i += entry.getItemHeight();
+            return i;
+        }
+        return 24;
+    }
+
+    @Override
+    public List<? extends Element> children() {
+        return children;
+    }
+
+    @Override
+    public void save() {
+        entries.forEach(AbstractConfigListEntry::save);
+    }
+
+    @Override
+    public Optional<String> getError() {
+        List<String> errors = entries.stream()
+                .map(AbstractConfigListEntry::getConfigError)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        if (errors.size() > 1)
+            return Optional.of(I18n.translate("text.cloth-config.multi_error"));
+        else
+            return errors.stream().findFirst();
+    }
+
+    public class CategoryLabelWidget implements Element {
+        private Rectangle rectangle = new Rectangle();
+
+        @Override
+        public boolean mouseClicked(double double_1, double double_2, int int_1) {
+            if (rectangle.contains(double_1, double_2)) {
+                expanded = !expanded;
+                MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
+                return true;
+            }
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/NestedListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/NestedListListEntry.java
@@ -1,0 +1,109 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import me.shedaniel.clothconfig2.gui.entries.NestedListListEntry.NestedListCell;
+import net.minecraft.client.gui.Element;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * @param <T>     the configuration object type
+ * @param <INNER> the type of the inner config entry
+ */
+public final class NestedListListEntry<T, INNER extends AbstractConfigListEntry<T>> extends AbstractListListEntry<T, NestedListCell<T, INNER>, NestedListListEntry<T, INNER>> {
+
+    @ApiStatus.Internal
+    public NestedListListEntry(
+            String fieldName,
+            List<T> value,
+            boolean defaultExpanded,
+            Supplier<Optional<String[]>> tooltipSupplier,
+            Consumer<List<T>> saveConsumer,
+            Supplier<List<T>> defaultValue,
+            String resetButtonKey,
+            boolean deleteButtonEnabled,
+            boolean insertInFront,
+            BiFunction<T, NestedListListEntry<T, INNER>, INNER> createNewCell
+    ) {
+        super(
+                fieldName,
+                value,
+                defaultExpanded,
+                null,
+                null,
+                defaultValue,
+                resetButtonKey,
+                false,
+                deleteButtonEnabled,
+                insertInFront,
+                (t, nestedListListEntry) -> new NestedListCell<>(t, nestedListListEntry, createNewCell.apply(t, nestedListListEntry))
+        );
+    }
+
+    @Override
+    public boolean isRequiresRestart() {
+        return cells.stream().anyMatch(NestedListCell::isRequiresRestart);
+    }
+
+    @Override
+    public void setRequiresRestart(boolean requiresRestart) {
+    }
+
+    @Override
+    public NestedListListEntry<T, INNER> self() {
+        return this;
+    }
+
+    /**
+     * @param <T> the configuration object type
+     * @see NestedListListEntry
+     */
+    public static class NestedListCell<T, INNER extends AbstractConfigListEntry<T>> extends AbstractListListEntry.AbstractListCell<T, NestedListCell<T, INNER>, NestedListListEntry<T, INNER>> {
+
+        private final INNER nestedEntry;
+
+        @ApiStatus.Internal
+        public NestedListCell(@Nullable T value, NestedListListEntry<T, INNER> listListEntry, INNER nestedEntry) {
+            super(value, listListEntry);
+            this.nestedEntry = nestedEntry;
+        }
+
+        @Override
+        public T getValue() {
+            return nestedEntry.getValue();
+        }
+
+        @Override
+        public Optional<String> getError() {
+            return nestedEntry.getError();
+        }
+
+        @Override
+        public int getCellHeight() {
+            return nestedEntry.getItemHeight();
+        }
+
+        @Override
+        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
+            nestedEntry.setScreen(listListEntry.getScreen());
+            nestedEntry.render(index, y, x, entryWidth, entryHeight, mouseX, mouseY, isSelected, delta);
+        }
+
+        @Override
+        public List<? extends Element> children() {
+            return Collections.singletonList(nestedEntry);
+        }
+
+        private boolean isRequiresRestart() {
+            return nestedEntry.isRequiresRestart();
+        }
+    }
+
+}

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/SelectionListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/SelectionListEntry.java
@@ -7,8 +7,8 @@ import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.Window;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -120,7 +120,7 @@ public class SelectionListEntry<T> extends TooltipListEntry<T> {
     }
     
     public static interface Translatable {
-        @Nonnull
+        @NotNull
         String getKey();
     }
     

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
@@ -23,7 +23,11 @@ public class StringListListEntry extends BaseListEntry<String, StringListListEnt
 
     @Deprecated
     public StringListListEntry(String fieldName, List<String> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new StringListCell("", (StringListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, true, true);
+    }
+
+    public StringListListEntry(String fieldName, List<String> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new StringListCell("", baseListEntry), saveConsumer, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
         for (String str : value)
             cells.add(new StringListCell(str, this));
         this.widgets.addAll(cells);

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
@@ -12,48 +12,53 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class StringListListEntry extends BaseListEntry<String, StringListListEntry.StringListCell> {
-    
+public class StringListListEntry extends BaseListEntry<String, StringListListEntry.StringListCell, StringListListEntry> {
+
     private Function<String, Optional<String>> cellErrorSupplier;
-    
+
     @Deprecated
     public StringListListEntry(String fieldName, List<String> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey) {
         this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
-    
+
     @Deprecated
     public StringListListEntry(String fieldName, List<String> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new StringListCell("", (StringListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
-        for(String str : value)
+        for (String str : value)
             cells.add(new StringListCell(str, this));
         this.widgets.addAll(cells);
         expended = defaultExpended;
     }
-    
+
     public Function<String, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public void setCellErrorSupplier(Function<String, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
     }
-    
+
     @Override
     public List<String> getValue() {
         return cells.stream().map(cell -> cell.widget.getText()).collect(Collectors.toList());
     }
-    
+
+    @Override
+    public StringListListEntry self() {
+        return this;
+    }
+
     @Override
     protected StringListCell getFromValue(String value) {
         return new StringListCell(value, this);
     }
-    
+
     public static class StringListCell extends BaseListCell {
-        
+
         private TextFieldWidget widget;
         private boolean isSelected;
         private StringListListEntry listListEntry;
-        
+
         public StringListCell(String value, StringListListEntry listListEntry) {
             this.listListEntry = listListEntry;
             this.setErrorSupplier(() -> listListEntry.cellErrorSupplier == null ? Optional.empty() : listListEntry.getCellErrorSupplier().apply(widget.getText()));
@@ -75,17 +80,17 @@ public class StringListListEntry extends BaseListEntry<String, StringListListEnt
                     listListEntry.getScreen().setEdited(true, listListEntry.isRequiresRestart());
             });
         }
-        
+
         @Override
         public Optional<String> getError() {
             return Optional.empty();
         }
-        
+
         @Override
         public int getCellHeight() {
             return 20;
         }
-        
+
         @Override
         public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
             widget.setWidth(entryWidth - 12);
@@ -97,12 +102,12 @@ public class StringListListEntry extends BaseListEntry<String, StringListListEnt
             if (isSelected && listListEntry.isEditable())
                 fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
         }
-        
+
         @Override
         public List<? extends Element> children() {
             return Collections.singletonList(widget);
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
@@ -17,17 +17,17 @@ public class StringListListEntry extends BaseListEntry<String, StringListListEnt
     private Function<String, Optional<String>> cellErrorSupplier;
 
     @Deprecated
-    public StringListListEntry(String fieldName, List<String> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey) {
-        this(fieldName, value, defaultExpended, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
+    public StringListListEntry(String fieldName, List<String> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey) {
+        this(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, false);
     }
 
     @Deprecated
-    public StringListListEntry(String fieldName, List<String> value, boolean defaultExpended, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey, boolean requiresRestart) {
+    public StringListListEntry(String fieldName, List<String> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, defaultValue, baseListEntry -> new StringListCell("", (StringListListEntry) baseListEntry), saveConsumer, resetButtonKey, requiresRestart);
         for (String str : value)
             cells.add(new StringListCell(str, this));
         this.widgets.addAll(cells);
-        expended = defaultExpended;
+        expanded = defaultExpanded;
     }
 
     public Function<String, Optional<String>> getCellErrorSupplier() {

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/StringListListEntry.java
@@ -1,20 +1,16 @@
 package me.shedaniel.clothconfig2.gui.entries;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.Element;
-import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @ApiStatus.Internal
-public class StringListListEntry extends AbstractListListEntry<String, StringListListEntry.StringListCell, StringListListEntry> {
+public class StringListListEntry extends AbstractTextFieldListListEntry<String, StringListListEntry.StringListCell, StringListListEntry> {
 
     @Deprecated
     public StringListListEntry(String fieldName, List<String> value, boolean defaultExpanded, Supplier<Optional<String[]>> tooltipSupplier, Consumer<List<String>> saveConsumer, Supplier<List<String>> defaultValue, String resetButtonKey) {
@@ -31,42 +27,28 @@ public class StringListListEntry extends AbstractListListEntry<String, StringLis
     }
 
     @Override
-    public List<String> getValue() {
-        return cells.stream().map(cell -> cell.widget.getText()).collect(Collectors.toList());
-    }
-
-    @Override
     public StringListListEntry self() {
         return this;
     }
 
-    @Override
-    protected StringListCell getFromValue(String value) {
-        return new StringListCell(value, this);
-    }
-
-    public static class StringListCell extends AbstractListListEntry.AbstractListCell<String, StringListCell, StringListListEntry> {
-
-        private TextFieldWidget widget;
+    public static class StringListCell extends AbstractTextFieldListListEntry.AbstractTextFieldListCell<String, StringListCell, StringListListEntry> {
 
         public StringListCell(String value, StringListListEntry listListEntry) {
             super(value, listListEntry);
+        }
 
+        @Nullable
+        @Override
+        protected String substituteDefault(@Nullable String value) {
             if (value == null)
-                value = "";
-            String finalValue = value;
+                return "";
+            else
+                return value;
+        }
 
-            this.setErrorSupplier(() -> Optional.ofNullable(listListEntry.cellErrorSupplier).flatMap(fn -> fn.apply(this.getValue())));
-            widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 100, 18, "");
-            widget.setMaxLength(Integer.MAX_VALUE);
-            widget.setHasBorder(false);
-            widget.setText(value);
-            widget.setChangedListener(s -> {
-                widget.setEditableColor(getPreferredTextColor());
-                if (!Objects.equals(s, finalValue)) {
-                    this.listListEntry.getScreen().setEdited(true, this.listListEntry.isRequiresRestart());
-                }
-            });
+        @Override
+        protected boolean isValidText(@NotNull String text) {
+            return true;
         }
 
         @Override
@@ -77,27 +59,6 @@ public class StringListListEntry extends AbstractListListEntry<String, StringLis
         @Override
         public Optional<String> getError() {
             return Optional.empty();
-        }
-
-        @Override
-        public int getCellHeight() {
-            return 20;
-        }
-
-        @Override
-        public void render(int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta) {
-            widget.setWidth(entryWidth - 12);
-            widget.x = x;
-            widget.y = y + 1;
-            widget.setEditable(listListEntry.isEditable());
-            widget.render(mouseX, mouseY, delta);
-            if (isSelected && listListEntry.isEditable())
-                fill(x, y + 12, x + entryWidth - 12, y + 13, getConfigError().isPresent() ? 0xffff5555 : 0xffe0e0e0);
-        }
-
-        @Override
-        public List<? extends Element> children() {
-            return Collections.singletonList(widget);
         }
 
     }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
@@ -16,20 +16,20 @@ import java.util.List;
 import java.util.Optional;
 
 public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigListEntry>> {
-    
+
     private static final Identifier CONFIG_TEX = new Identifier("cloth-config2", "textures/gui/cloth_config.png");
     private String categoryName;
     private List<AbstractConfigListEntry> entries;
     private CategoryLabelWidget widget;
     private List<Element> children;
-    private boolean expended;
-    
+    private boolean expanded;
+
     @Deprecated
-    public SubCategoryListEntry(String categoryName, List<AbstractConfigListEntry> entries, boolean defaultExpended) {
+    public SubCategoryListEntry(String categoryName, List<AbstractConfigListEntry> entries, boolean defaultExpanded) {
         super(categoryName, null);
         this.categoryName = categoryName;
         this.entries = entries;
-        this.expended = defaultExpended;
+        this.expanded = defaultExpanded;
         this.widget = new CategoryLabelWidget();
         this.children = Lists.newArrayList(widget);
         this.children.addAll(entries);
@@ -72,15 +72,15 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
         MinecraftClient.getInstance().getTextureManager().bindTexture(CONFIG_TEX);
         DiffuseLighting.disable();
         RenderSystem.color4f(1, 1, 1, 1);
-        blit(x - 15, y + 4, 24, (widget.rectangle.contains(mouseX, mouseY) ? 18 : 0) + (expended ? 9 : 0), 9, 9);
+        blit(x - 15, y + 4, 24, (widget.rectangle.contains(mouseX, mouseY) ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
         MinecraftClient.getInstance().textRenderer.drawWithShadow(I18n.translate(categoryName), x, y + 5, widget.rectangle.contains(mouseX, mouseY) ? 0xffe6fe16 : -1);
         for(AbstractConfigListEntry entry : entries) {
             entry.setParent(getParent());
             entry.setScreen(getScreen());
         }
-        if (expended) {
+        if (expanded) {
             int yy = y + 24;
-            for(AbstractConfigListEntry entry : entries) {
+            for (AbstractConfigListEntry entry : entries) {
                 entry.render(-1, yy, x + 14, entryWidth - 14, entry.getItemHeight(), mouseX, mouseY, isSelected, delta);
                 yy += entry.getItemHeight();
             }
@@ -98,9 +98,9 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     
     @Override
     public int getItemHeight() {
-        if (expended) {
+        if (expanded) {
             int i = 24;
-            for(AbstractConfigListEntry entry : entries)
+            for (AbstractConfigListEntry entry : entries)
                 i += entry.getItemHeight();
             return i;
         }
@@ -135,7 +135,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
         @Override
         public boolean mouseClicked(double double_1, double double_2, int int_1) {
             if (rectangle.contains(double_1, double_2)) {
-                expended = !expended;
+                expanded = !expanded;
                 MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
             }

--- a/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
+++ b/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
@@ -3,23 +3,24 @@ package me.shedaniel.clothconfig2.gui.entries;
 import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
 import me.shedaniel.clothconfig2.api.QueuedTooltip;
 import me.shedaniel.math.api.Point;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 public abstract class TooltipListEntry<T> extends AbstractConfigListEntry<T> {
-    
-    @Nullable private Supplier<Optional<String[]>> tooltipSupplier;
-    
+
+    @Nullable
+    private Supplier<Optional<String[]>> tooltipSupplier;
+
     @Deprecated
     public TooltipListEntry(String fieldName, @Nullable Supplier<Optional<String[]>> tooltipSupplier) {
         this(fieldName, tooltipSupplier, false);
     }
-    
+
     @Deprecated
     public TooltipListEntry(String fieldName,
-            @Nullable Supplier<Optional<String[]>> tooltipSupplier, boolean requiresRestart) {
+                            @Nullable Supplier<Optional<String[]>> tooltipSupplier, boolean requiresRestart) {
         super(fieldName, requiresRestart);
         this.tooltipSupplier = tooltipSupplier;
     }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/ScissorsHandlerImpl.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/ScissorsHandlerImpl.java
@@ -1,11 +1,10 @@
 package me.shedaniel.clothconfig2.impl;
 
 import com.google.common.collect.Lists;
+import fudge.notenoughcrashes.api.MinecraftCrashes;
 import me.shedaniel.clothconfig2.ClothConfigInitializer;
 import me.shedaniel.clothconfig2.api.ScissorsHandler;
-import me.shedaniel.math.api.Executor;
 import me.shedaniel.math.api.Rectangle;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.Window;
 import org.lwjgl.opengl.GL11;
@@ -15,17 +14,16 @@ import java.util.List;
 
 public final class ScissorsHandlerImpl implements ScissorsHandler {
 
-    @Deprecated public static final ScissorsHandler INSTANCE = new ScissorsHandlerImpl();
+    @Deprecated
+    public static final ScissorsHandler INSTANCE = new ScissorsHandlerImpl();
 
     static {
-        Executor.runIf(() -> FabricLoader.getInstance().isModLoaded("notenoughcrashes"), () -> () -> {
-            fudge.notenoughcrashes.api.NotEnoughCrashesApi.onEveryCrash(() -> {
-                try {
-                    ScissorsHandler.INSTANCE.clearScissors();
-                } catch (Throwable t) {
-                    ClothConfigInitializer.LOGGER.error("[ClothConfig] Failed clear scissors on game crash!", t);
-                }
-            });
+        MinecraftCrashes.onEveryCrash(() -> {
+            try {
+                ScissorsHandler.INSTANCE.clearScissors();
+            } catch (Throwable t) {
+                ClothConfigInitializer.LOGGER.error("[ClothConfig] Failed clear scissors on game crash!", t);
+            }
         });
     }
 

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/BooleanToggleBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/BooleanToggleBuilder.java
@@ -1,81 +1,85 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.BooleanListEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class BooleanToggleBuilder extends FieldBuilder<Boolean, BooleanListEntry> {
-    
-    @Nullable private Consumer<Boolean> saveConsumer = null;
-    @Nonnull private Function<Boolean, Optional<String[]>> tooltipSupplier = bool -> Optional.empty();
+
+    @Nullable
+    private Consumer<Boolean> saveConsumer = null;
+    @NotNull
+    private Function<Boolean, Optional<String[]>> tooltipSupplier = bool -> Optional.empty();
     private boolean value;
-    @Nullable private Function<Boolean, String> yesNoTextSupplier = null;
-    
+    @Nullable
+    private Function<Boolean, String> yesNoTextSupplier = null;
+
     public BooleanToggleBuilder(String resetButtonKey, String fieldNameKey, boolean value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public BooleanToggleBuilder setErrorSupplier(@Nullable Function<Boolean, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public BooleanToggleBuilder requireRestart() {
         requireRestart(true);
         return this;
     }
-    
+
     public BooleanToggleBuilder setSaveConsumer(Consumer<Boolean> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public BooleanToggleBuilder setDefaultValue(Supplier<Boolean> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public BooleanToggleBuilder setDefaultValue(boolean defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
-    public BooleanToggleBuilder setTooltipSupplier(@Nonnull Function<Boolean, Optional<String[]>> tooltipSupplier) {
+
+    public BooleanToggleBuilder setTooltipSupplier(@NotNull Function<Boolean, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
-    public BooleanToggleBuilder setTooltipSupplier(@Nonnull Supplier<Optional<String[]>> tooltipSupplier) {
+
+    public BooleanToggleBuilder setTooltipSupplier(@NotNull Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = bool -> tooltipSupplier.get();
         return this;
     }
-    
+
     public BooleanToggleBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = bool -> tooltip;
         return this;
     }
-    
+
     public BooleanToggleBuilder setTooltip(@Nullable String... tooltip) {
         this.tooltipSupplier = bool -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     @Nullable
     public Function<Boolean, String> getYesNoTextSupplier() {
         return yesNoTextSupplier;
     }
-    
+
     public BooleanToggleBuilder setYesNoTextSupplier(@Nullable Function<Boolean, String> yesNoTextSupplier) {
         this.yesNoTextSupplier = yesNoTextSupplier;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public BooleanListEntry build() {
         BooleanListEntry entry = new BooleanListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart()) {
@@ -91,5 +95,5 @@ public class BooleanToggleBuilder extends FieldBuilder<Boolean, BooleanListEntry
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.DoubleListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -73,17 +74,18 @@ public class DoubleFieldBuilder extends FieldBuilder<Double, DoubleListEntry> {
         this.tooltipSupplier = d -> tooltipSupplier.get();
         return this;
     }
-    
+
     public DoubleFieldBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = d -> tooltip;
         return this;
     }
-    
+
     public DoubleFieldBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = d -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @NotNull
     @Override
     public DoubleListEntry build() {
         DoubleListEntry entry = new DoubleListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
@@ -134,17 +134,7 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
     @NotNull
     @Override
     public DoubleListListEntry build() {
-        DoubleListListEntry entry = new DoubleListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
-            @Override
-            public boolean isDeleteButtonEnabled() {
-                return deleteButtonEnabled;
-            }
-
-            @Override
-            public boolean insertInFront() {
-                return insertInFront;
-            }
-        };
+        DoubleListListEntry entry = new DoubleListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), requireRestart, deleteButtonEnabled, insertInFront);
         if (min != null)
             entry.setMinimum(min);
         if (max != null)

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
@@ -2,8 +2,8 @@ package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.DoubleListListEntry;
 import net.minecraft.client.resource.language.I18n;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -11,56 +11,56 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListListEntry> {
-    
+
     protected Function<Double, Optional<String>> cellErrorSupplier;
     private Consumer<List<Double>> saveConsumer = null;
     private Function<List<Double>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Double> value;
-    private boolean expended = false;
+    private boolean expanded = false;
     private Double min = null, max = null;
     private Function<DoubleListListEntry, DoubleListListEntry.DoubleListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
-    
+
     public DoubleListBuilder(String resetButtonKey, String fieldNameKey, List<Double> value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public Function<Double, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public DoubleListBuilder setCellErrorSupplier(Function<Double, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
         return this;
     }
-    
+
     public DoubleListBuilder setErrorSupplier(Function<List<Double>, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public DoubleListBuilder setDeleteButtonEnabled(boolean deleteButtonEnabled) {
         this.deleteButtonEnabled = deleteButtonEnabled;
         return this;
     }
-    
+
     public DoubleListBuilder setInsertInFront(boolean insertInFront) {
         this.insertInFront = insertInFront;
         return this;
     }
-    
+
     public DoubleListBuilder setAddButtonTooltip(String addTooltip) {
         this.addTooltip = addTooltip;
         return this;
     }
-    
+
     public DoubleListBuilder setRemoveButtonTooltip(String removeTooltip) {
         this.removeTooltip = removeTooltip;
         return this;
     }
-    
+
     public DoubleListBuilder requireRestart() {
         requireRestart(true);
         return this;
@@ -70,68 +70,68 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
         this.createNewInstance = createNewInstance;
         return this;
     }
-    
-    public DoubleListBuilder setExpended(boolean expended) {
-        this.expended = expended;
+
+    public DoubleListBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
-    
+
     public DoubleListBuilder setSaveConsumer(Consumer<List<Double>> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public DoubleListBuilder setDefaultValue(Supplier<List<Double>> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public DoubleListBuilder setMin(double min) {
         this.min = min;
         return this;
     }
-    
+
     public DoubleListBuilder setMax(double max) {
         this.max = max;
         return this;
     }
-    
+
     public DoubleListBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public DoubleListBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
     public DoubleListBuilder setDefaultValue(List<Double> defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
+
     public DoubleListBuilder setTooltipSupplier(Function<List<Double>, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public DoubleListBuilder setTooltipSupplier(Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = list -> tooltipSupplier.get();
         return this;
     }
-    
+
     public DoubleListBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public DoubleListBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public DoubleListListEntry build() {
         DoubleListListEntry entry = new DoubleListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
@@ -159,5 +159,5 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
@@ -1,9 +1,9 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
-import me.shedaniel.clothconfig2.gui.entries.BaseListEntry;
 import me.shedaniel.clothconfig2.gui.entries.DoubleListListEntry;
 import net.minecraft.client.resource.language.I18n;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -18,7 +18,7 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
     private List<Double> value;
     private boolean expended = false;
     private Double min = null, max = null;
-    private Function<BaseListEntry, DoubleListListEntry.DoubleListCell> createNewInstance;
+    private Function<DoubleListListEntry, DoubleListListEntry.DoubleListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
     
@@ -65,8 +65,8 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
         requireRestart(true);
         return this;
     }
-    
-    public DoubleListBuilder setCreateNewInstance(Function<BaseListEntry, DoubleListListEntry.DoubleListCell> createNewInstance) {
+
+    public DoubleListBuilder setCreateNewInstance(Function<DoubleListListEntry, DoubleListListEntry.DoubleListCell> createNewInstance) {
         this.createNewInstance = createNewInstance;
         return this;
     }
@@ -130,7 +130,8 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @Nonnull
     @Override
     public DoubleListListEntry build() {
         DoubleListListEntry entry = new DoubleListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
@@ -138,7 +139,7 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;
             }
-            
+
             @Override
             public boolean insertInFront() {
                 return insertInFront;

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
@@ -13,8 +13,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -74,18 +74,18 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>>
         this.tooltipSupplier = str -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     public DropdownMenuBuilder<T> requireRestart() {
         requireRestart(true);
         return this;
     }
-    
+
     public DropdownMenuBuilder<T> setErrorSupplier(Function<T, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
-    @Nonnull
+
+    @NotNull
     @Override
     public DropdownBoxEntry<T> build() {
         DropdownBoxEntry<T> entry = new DropdownBoxEntry<T>(getFieldNameKey(), getResetButtonKey(), null, isRequireRestart(), defaultValue, saveConsumer, selections, topCellElement, cellCreator);
@@ -94,7 +94,7 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>>
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
     public static class TopCellElementBuilder {
         public static final Function<String, Identifier> IDENTIFIER_FUNCTION = str -> {
             try {

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/EnumSelectorBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/EnumSelectorBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.EnumListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -64,18 +65,19 @@ public class EnumSelectorBuilder<T extends Enum<?>> extends FieldBuilder<T, Enum
         this.tooltipSupplier = e -> tooltip;
         return this;
     }
-    
+
     public EnumSelectorBuilder<T> setTooltip(String... tooltip) {
         this.tooltipSupplier = e -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     public EnumSelectorBuilder<T> setEnumNameProvider(Function<Enum, String> enumNameProvider) {
         Objects.requireNonNull(enumNameProvider);
         this.enumNameProvider = enumNameProvider;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public EnumListEntry<T> build() {
         EnumListEntry<T> entry = new EnumListEntry<>(getFieldNameKey(), clazz, value, getResetButtonKey(), defaultValue, saveConsumer, enumNameProvider, null, isRequireRestart());
@@ -84,5 +86,5 @@ public class EnumSelectorBuilder<T extends Enum<?>> extends FieldBuilder<T, Enum
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/FieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/FieldBuilder.java
@@ -1,55 +1,60 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public abstract class FieldBuilder<T, A extends AbstractConfigListEntry> {
-    @Nonnull private final String fieldNameKey;
-    @Nonnull private final String resetButtonKey;
+    @NotNull
+    private final String fieldNameKey;
+    @NotNull
+    private final String resetButtonKey;
     protected boolean requireRestart = false;
-    @Nullable protected Supplier<T> defaultValue = null;
-    @Nullable protected Function<T, Optional<String>> errorSupplier;
-    
+    @Nullable
+    protected Supplier<T> defaultValue = null;
+    @Nullable
+    protected Function<T, Optional<String>> errorSupplier;
+
     protected FieldBuilder(String resetButtonKey, String fieldNameKey) {
         this.resetButtonKey = Objects.requireNonNull(resetButtonKey);
         this.fieldNameKey = Objects.requireNonNull(fieldNameKey);
     }
-    
+
     @Nullable
     public final Supplier<T> getDefaultValue() {
         return defaultValue;
     }
-    
+
+    @SuppressWarnings("rawtypes")
     @Deprecated
     public final AbstractConfigListEntry buildEntry() {
         return build();
     }
-    
-    @Nonnull
+
+    @NotNull
     public abstract A build();
-    
-    @Nonnull
+
+    @NotNull
     public final String getFieldNameKey() {
         return fieldNameKey;
     }
-    
-    @Nonnull
+
+    @NotNull
     public final String getResetButtonKey() {
         return resetButtonKey;
     }
-    
+
     public boolean isRequireRestart() {
         return requireRestart;
     }
-    
+
     public void requireRestart(boolean requireRestart) {
         this.requireRestart = requireRestart;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.FloatListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -73,17 +74,18 @@ public class FloatFieldBuilder extends FieldBuilder<Float, FloatListEntry> {
         this.max = max;
         return this;
     }
-    
+
     public FloatFieldBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public FloatFieldBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public FloatListEntry build() {
         FloatListEntry entry = new FloatListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
@@ -1,9 +1,9 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
-import me.shedaniel.clothconfig2.gui.entries.BaseListEntry;
 import me.shedaniel.clothconfig2.gui.entries.FloatListListEntry;
 import net.minecraft.client.resource.language.I18n;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -11,126 +11,127 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEntry> {
-    
+
     protected Function<Float, Optional<String>> cellErrorSupplier;
     private Consumer<List<Float>> saveConsumer = null;
     private Function<List<Float>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Float> value;
     private boolean expended = false;
     private Float min = null, max = null;
-    private Function<BaseListEntry, FloatListListEntry.FloatListCell> createNewInstance;
+    private Function<FloatListListEntry, FloatListListEntry.FloatListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
-    
+
     public FloatListBuilder(String resetButtonKey, String fieldNameKey, List<Float> value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public Function<Float, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public FloatListBuilder setCellErrorSupplier(Function<Float, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
         return this;
     }
-    
+
     public FloatListBuilder setDeleteButtonEnabled(boolean deleteButtonEnabled) {
         this.deleteButtonEnabled = deleteButtonEnabled;
         return this;
     }
-    
+
     public FloatListBuilder setErrorSupplier(Function<List<Float>, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public FloatListBuilder setInsertInFront(boolean insertInFront) {
         this.insertInFront = insertInFront;
         return this;
     }
-    
+
     public FloatListBuilder setAddButtonTooltip(String addTooltip) {
         this.addTooltip = addTooltip;
         return this;
     }
-    
+
     public FloatListBuilder setRemoveButtonTooltip(String removeTooltip) {
         this.removeTooltip = removeTooltip;
         return this;
     }
-    
+
     public FloatListBuilder requireRestart() {
         requireRestart(true);
         return this;
     }
-    
-    public FloatListBuilder setCreateNewInstance(Function<BaseListEntry, FloatListListEntry.FloatListCell> createNewInstance) {
+
+    public FloatListBuilder setCreateNewInstance(Function<FloatListListEntry, FloatListListEntry.FloatListCell> createNewInstance) {
         this.createNewInstance = createNewInstance;
         return this;
     }
-    
+
     public FloatListBuilder setExpended(boolean expended) {
         this.expended = expended;
         return this;
     }
-    
+
     public FloatListBuilder setSaveConsumer(Consumer<List<Float>> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public FloatListBuilder setDefaultValue(Supplier<List<Float>> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public FloatListBuilder setMin(float min) {
         this.min = min;
         return this;
     }
-    
+
     public FloatListBuilder setMax(float max) {
         this.max = max;
         return this;
     }
-    
+
     public FloatListBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public FloatListBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
     public FloatListBuilder setDefaultValue(List<Float> defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
+
     public FloatListBuilder setTooltipSupplier(Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = list -> tooltipSupplier.get();
         return this;
     }
-    
+
     public FloatListBuilder setTooltipSupplier(Function<List<Float>, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public FloatListBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public FloatListBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @Nonnull
     @Override
     public FloatListListEntry build() {
         FloatListListEntry entry = new FloatListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
@@ -138,7 +139,7 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;
             }
-            
+
             @Override
             public boolean insertInFront() {
                 return insertInFront;
@@ -158,5 +159,5 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
@@ -134,17 +134,7 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
     @NotNull
     @Override
     public FloatListListEntry build() {
-        FloatListListEntry entry = new FloatListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
-            @Override
-            public boolean isDeleteButtonEnabled() {
-                return deleteButtonEnabled;
-            }
-
-            @Override
-            public boolean insertInFront() {
-                return insertInFront;
-            }
-        };
+        FloatListListEntry entry = new FloatListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart(), deleteButtonEnabled, insertInFront);
         if (min != null)
             entry.setMinimum(min);
         if (max != null)

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
@@ -2,8 +2,8 @@ package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.FloatListListEntry;
 import net.minecraft.client.resource.language.I18n;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -16,7 +16,7 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
     private Consumer<List<Float>> saveConsumer = null;
     private Function<List<Float>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Float> value;
-    private boolean expended = false;
+    private boolean expanded = false;
     private Float min = null, max = null;
     private Function<FloatListListEntry, FloatListListEntry.FloatListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
@@ -71,8 +71,8 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
         return this;
     }
 
-    public FloatListBuilder setExpended(boolean expended) {
-        this.expended = expended;
+    public FloatListBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
 
@@ -131,7 +131,7 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public FloatListListEntry build() {
         FloatListListEntry entry = new FloatListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.IntegerListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -73,17 +74,18 @@ public class IntFieldBuilder extends FieldBuilder<Integer, IntegerListEntry> {
         this.max = max;
         return this;
     }
-    
+
     public IntFieldBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public IntFieldBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public IntegerListEntry build() {
         IntegerListEntry entry = new IntegerListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
@@ -2,8 +2,8 @@ package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.IntegerListListEntry;
 import net.minecraft.client.resource.language.I18n;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -16,7 +16,7 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
     private Consumer<List<Integer>> saveConsumer = null;
     private Function<List<Integer>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Integer> value;
-    private boolean expended = false;
+    private boolean expanded = false;
     private Integer min = null, max = null;
     private Function<IntegerListListEntry, IntegerListListEntry.IntegerListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
@@ -71,8 +71,8 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
         return this;
     }
 
-    public IntListBuilder setExpended(boolean expended) {
-        this.expended = expended;
+    public IntListBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
 
@@ -131,10 +131,10 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IntegerListListEntry build() {
-        IntegerListListEntry entry = new IntegerListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
+        IntegerListListEntry entry = new IntegerListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
             @Override
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
@@ -134,17 +134,7 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
     @NotNull
     @Override
     public IntegerListListEntry build() {
-        IntegerListListEntry entry = new IntegerListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
-            @Override
-            public boolean isDeleteButtonEnabled() {
-                return deleteButtonEnabled;
-            }
-
-            @Override
-            public boolean insertInFront() {
-                return insertInFront;
-            }
-        };
+        IntegerListListEntry entry = new IntegerListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart(), deleteButtonEnabled, insertInFront);
         if (min != null)
             entry.setMinimum(min);
         if (max != null)

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
@@ -1,9 +1,9 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
-import me.shedaniel.clothconfig2.gui.entries.BaseListEntry;
 import me.shedaniel.clothconfig2.gui.entries.IntegerListListEntry;
 import net.minecraft.client.resource.language.I18n;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -11,126 +11,127 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListEntry> {
-    
+
     protected Function<Integer, Optional<String>> cellErrorSupplier;
     private Consumer<List<Integer>> saveConsumer = null;
     private Function<List<Integer>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Integer> value;
     private boolean expended = false;
     private Integer min = null, max = null;
-    private Function<BaseListEntry, IntegerListListEntry.IntegerListCell> createNewInstance;
+    private Function<IntegerListListEntry, IntegerListListEntry.IntegerListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
-    
+
     public IntListBuilder(String resetButtonKey, String fieldNameKey, List<Integer> value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public Function<Integer, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public IntListBuilder setCellErrorSupplier(Function<Integer, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
         return this;
     }
-    
+
     public IntListBuilder setErrorSupplier(Function<List<Integer>, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public IntListBuilder setDeleteButtonEnabled(boolean deleteButtonEnabled) {
         this.deleteButtonEnabled = deleteButtonEnabled;
         return this;
     }
-    
+
     public IntListBuilder setInsertInFront(boolean insertInFront) {
         this.insertInFront = insertInFront;
         return this;
     }
-    
+
     public IntListBuilder setAddButtonTooltip(String addTooltip) {
         this.addTooltip = addTooltip;
         return this;
     }
-    
+
     public IntListBuilder setRemoveButtonTooltip(String removeTooltip) {
         this.removeTooltip = removeTooltip;
         return this;
     }
-    
+
     public IntListBuilder requireRestart() {
         requireRestart(true);
         return this;
     }
-    
-    public IntListBuilder setCreateNewInstance(Function<BaseListEntry, IntegerListListEntry.IntegerListCell> createNewInstance) {
+
+    public IntListBuilder setCreateNewInstance(Function<IntegerListListEntry, IntegerListListEntry.IntegerListCell> createNewInstance) {
         this.createNewInstance = createNewInstance;
         return this;
     }
-    
+
     public IntListBuilder setExpended(boolean expended) {
         this.expended = expended;
         return this;
     }
-    
+
     public IntListBuilder setSaveConsumer(Consumer<List<Integer>> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public IntListBuilder setDefaultValue(Supplier<List<Integer>> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public IntListBuilder setMin(int min) {
         this.min = min;
         return this;
     }
-    
+
     public IntListBuilder setMax(int max) {
         this.max = max;
         return this;
     }
-    
+
     public IntListBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public IntListBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
     public IntListBuilder setDefaultValue(List<Integer> defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
+
     public IntListBuilder setTooltipSupplier(Function<List<Integer>, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public IntListBuilder setTooltipSupplier(Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = list -> tooltipSupplier.get();
         return this;
     }
-    
+
     public IntListBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public IntListBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @Nonnull
     @Override
     public IntegerListListEntry build() {
         IntegerListListEntry entry = new IntegerListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
@@ -138,7 +139,7 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;
             }
-            
+
             @Override
             public boolean insertInFront() {
                 return insertInFront;
@@ -158,5 +159,5 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.IntegerSliderEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -70,17 +71,18 @@ public class IntSliderBuilder extends FieldBuilder<Integer, IntegerSliderEntry> 
         this.tooltipSupplier = i -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     public IntSliderBuilder setMax(int max) {
         this.max = max;
         return this;
     }
-    
+
     public IntSliderBuilder setMin(int min) {
         this.min = min;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public IntegerSliderEntry build() {
         IntegerSliderEntry entry = new IntegerSliderEntry(getFieldNameKey(), min, max, value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/KeyCodeBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/KeyCodeBuilder.java
@@ -4,26 +4,28 @@ import me.shedaniel.clothconfig2.api.Modifier;
 import me.shedaniel.clothconfig2.api.ModifierKeyCode;
 import me.shedaniel.clothconfig2.gui.entries.KeyCodeEntry;
 import net.minecraft.client.util.InputUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class KeyCodeBuilder extends FieldBuilder<ModifierKeyCode, KeyCodeEntry> {
-    
-    @Nullable private Consumer<ModifierKeyCode> saveConsumer = null;
-    @Nonnull private Function<ModifierKeyCode, Optional<String[]>> tooltipSupplier = bool -> Optional.empty();
+
+    @Nullable
+    private Consumer<ModifierKeyCode> saveConsumer = null;
+    @NotNull
+    private Function<ModifierKeyCode, Optional<String[]>> tooltipSupplier = bool -> Optional.empty();
     private ModifierKeyCode value;
     private boolean allowKey = true, allowMouse = true, allowModifiers = true;
-    
+
     public KeyCodeBuilder(String resetButtonKey, String fieldNameKey, ModifierKeyCode value) {
         super(resetButtonKey, fieldNameKey);
         this.value = ModifierKeyCode.copyOf(value);
     }
-    
+
     public KeyCodeBuilder setAllowModifiers(boolean allowModifiers) {
         this.allowModifiers = allowModifiers;
         if (!allowModifiers)
@@ -76,40 +78,41 @@ public class KeyCodeBuilder extends FieldBuilder<ModifierKeyCode, KeyCodeEntry> 
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public KeyCodeBuilder setDefaultValue(InputUtil.KeyCode defaultValue) {
         return setDefaultValue(ModifierKeyCode.of(defaultValue, Modifier.none()));
     }
-    
+
     public KeyCodeBuilder setDefaultValue(ModifierKeyCode defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
-    public KeyCodeBuilder setTooltipSupplier(@Nonnull Function<InputUtil.KeyCode, Optional<String[]>> tooltipSupplier) {
+
+    public KeyCodeBuilder setTooltipSupplier(@NotNull Function<InputUtil.KeyCode, Optional<String[]>> tooltipSupplier) {
         return setModifierTooltipSupplier(keyCode -> tooltipSupplier.apply(keyCode.getKeyCode()));
     }
-    
-    public KeyCodeBuilder setModifierTooltipSupplier(@Nonnull Function<ModifierKeyCode, Optional<String[]>> tooltipSupplier) {
+
+    public KeyCodeBuilder setModifierTooltipSupplier(@NotNull Function<ModifierKeyCode, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
-    public KeyCodeBuilder setTooltipSupplier(@Nonnull Supplier<Optional<String[]>> tooltipSupplier) {
+
+    public KeyCodeBuilder setTooltipSupplier(@NotNull Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = bool -> tooltipSupplier.get();
         return this;
     }
-    
+
     public KeyCodeBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = bool -> tooltip;
         return this;
     }
-    
+
     public KeyCodeBuilder setTooltip(@Nullable String... tooltip) {
         this.tooltipSupplier = bool -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @NotNull
     @Override
     public KeyCodeEntry build() {
         KeyCodeEntry entry = new KeyCodeEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.LongListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -73,17 +74,18 @@ public class LongFieldBuilder extends FieldBuilder<Long, LongListEntry> {
         this.max = max;
         return this;
     }
-    
+
     public LongFieldBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public LongFieldBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public LongListEntry build() {
         LongListEntry entry = new LongListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
@@ -2,8 +2,8 @@ package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.LongListListEntry;
 import net.minecraft.client.resource.language.I18n;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -16,7 +16,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
     private Consumer<List<Long>> saveConsumer = null;
     private Function<List<Long>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<Long> value;
-    private boolean expended = false;
+    private boolean expanded = false;
     private Long min = null, max = null;
     private Function<LongListListEntry, LongListListEntry.LongListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
@@ -60,7 +60,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         this.removeTooltip = removeTooltip;
         return this;
     }
-    
+
     public LongListBuilder requireRestart() {
         requireRestart(true);
         return this;
@@ -70,17 +70,17 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         this.createNewInstance = createNewInstance;
         return this;
     }
-    
-    public LongListBuilder setExpended(boolean expended) {
-        this.expended = expended;
+
+    public LongListBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
-    
+
     public LongListBuilder setSaveConsumer(Consumer<List<Long>> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public LongListBuilder setDefaultValue(Supplier<List<Long>> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
@@ -120,21 +120,21 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public LongListBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public LongListBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public LongListListEntry build() {
-        LongListListEntry entry = new LongListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
+        LongListListEntry entry = new LongListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
             @Override
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
@@ -1,9 +1,9 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
-import me.shedaniel.clothconfig2.gui.entries.BaseListEntry;
 import me.shedaniel.clothconfig2.gui.entries.LongListListEntry;
 import net.minecraft.client.resource.language.I18n;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -18,7 +18,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
     private List<Long> value;
     private boolean expended = false;
     private Long min = null, max = null;
-    private Function<BaseListEntry, LongListListEntry.LongListCell> createNewInstance;
+    private Function<LongListListEntry, LongListListEntry.LongListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
     
@@ -65,8 +65,8 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         requireRestart(true);
         return this;
     }
-    
-    public LongListBuilder setCreateNewInstance(Function<BaseListEntry, LongListListEntry.LongListCell> createNewInstance) {
+
+    public LongListBuilder setCreateNewInstance(Function<LongListListEntry, LongListListEntry.LongListCell> createNewInstance) {
         this.createNewInstance = createNewInstance;
         return this;
     }
@@ -130,7 +130,8 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @Nonnull
     @Override
     public LongListListEntry build() {
         LongListListEntry entry = new LongListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
@@ -138,7 +139,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
             public boolean isDeleteButtonEnabled() {
                 return deleteButtonEnabled;
             }
-            
+
             @Override
             public boolean insertInFront() {
                 return insertInFront;

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry> {
-    
+
     protected Function<Long, Optional<String>> cellErrorSupplier;
     private Consumer<List<Long>> saveConsumer = null;
     private Function<List<Long>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
@@ -21,41 +21,41 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
     private Function<LongListListEntry, LongListListEntry.LongListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
-    
+
     public LongListBuilder(String resetButtonKey, String fieldNameKey, List<Long> value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public Function<Long, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public LongListBuilder setCellErrorSupplier(Function<Long, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
         return this;
     }
-    
+
     public LongListBuilder setErrorSupplier(Function<List<Long>, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public LongListBuilder setDeleteButtonEnabled(boolean deleteButtonEnabled) {
         this.deleteButtonEnabled = deleteButtonEnabled;
         return this;
     }
-    
+
     public LongListBuilder setInsertInFront(boolean insertInFront) {
         this.insertInFront = insertInFront;
         return this;
     }
-    
+
     public LongListBuilder setAddButtonTooltip(String addTooltip) {
         this.addTooltip = addTooltip;
         return this;
     }
-    
+
     public LongListBuilder setRemoveButtonTooltip(String removeTooltip) {
         this.removeTooltip = removeTooltip;
         return this;
@@ -85,37 +85,37 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public LongListBuilder setMin(long min) {
         this.min = min;
         return this;
     }
-    
+
     public LongListBuilder setMax(long max) {
         this.max = max;
         return this;
     }
-    
+
     public LongListBuilder removeMin() {
         this.min = null;
         return this;
     }
-    
+
     public LongListBuilder removeMax() {
         this.max = null;
         return this;
     }
-    
+
     public LongListBuilder setDefaultValue(List<Long> defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
+
     public LongListBuilder setTooltipSupplier(Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = list -> tooltipSupplier.get();
         return this;
     }
-    
+
     public LongListBuilder setTooltipSupplier(Function<List<Long>, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
@@ -134,17 +134,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
     @NotNull
     @Override
     public LongListListEntry build() {
-        LongListListEntry entry = new LongListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart()) {
-            @Override
-            public boolean isDeleteButtonEnabled() {
-                return deleteButtonEnabled;
-            }
-
-            @Override
-            public boolean insertInFront() {
-                return insertInFront;
-            }
-        };
+        LongListListEntry entry = new LongListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart(), deleteButtonEnabled, insertInFront);
         if (min != null)
             entry.setMinimum(min);
         if (max != null)
@@ -159,5 +149,5 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.LongSliderEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -60,18 +61,19 @@ public class LongSliderBuilder extends FieldBuilder<Long, LongSliderEntry> {
         this.tooltipSupplier = i -> tooltipSupplier.get();
         return this;
     }
-    
+
     public LongSliderBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = i -> tooltip;
         return this;
     }
-    
+
     public LongSliderBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = i -> Optional.ofNullable(tooltip);
         return this;
     }
-    
-    
+
+
+    @NotNull
     @Override
     public LongSliderEntry build() {
         LongSliderEntry entry = new LongSliderEntry(getFieldNameKey(), min, max, value, saveConsumer, getResetButtonKey(), defaultValue, null, isRequireRestart());

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/SelectorBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/SelectorBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.SelectionListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -63,17 +64,18 @@ public class SelectorBuilder<T> extends FieldBuilder<T, SelectionListEntry<T>> {
         this.tooltipSupplier = e -> tooltip;
         return this;
     }
-    
+
     public SelectorBuilder<T> setTooltip(String... tooltip) {
         this.tooltipSupplier = e -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     public SelectorBuilder<T> setNameProvider(Function<T, String> enumNameProvider) {
         this.nameProvider = enumNameProvider;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public SelectionListEntry<T> build() {
         SelectionListEntry<T> entry = new SelectionListEntry<>(getFieldNameKey(), valuesArray, value, getResetButtonKey(), defaultValue, saveConsumer, nameProvider, null, isRequireRestart());
@@ -82,5 +84,5 @@ public class SelectorBuilder<T> extends FieldBuilder<T, SelectionListEntry<T>> {
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.StringListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -54,17 +55,18 @@ public class StringFieldBuilder extends FieldBuilder<String, StringListEntry> {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public StringFieldBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = str -> tooltip;
         return this;
     }
-    
+
     public StringFieldBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = str -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @NotNull
     @Override
     public StringListEntry build() {
         StringListEntry entry = new StringListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());
@@ -73,5 +75,5 @@ public class StringFieldBuilder extends FieldBuilder<String, StringListEntry> {
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
@@ -1,6 +1,5 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
-import me.shedaniel.clothconfig2.gui.entries.BaseListEntry;
 import me.shedaniel.clothconfig2.gui.entries.StringListListEntry;
 import net.minecraft.client.resource.language.I18n;
 
@@ -11,105 +10,105 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class StringListBuilder extends FieldBuilder<List<String>, StringListListEntry> {
-    
+
     private Function<String, Optional<String>> cellErrorSupplier;
     private Consumer<List<String>> saveConsumer = null;
     private Function<List<String>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<String> value;
     private boolean expended = false;
-    private Function<BaseListEntry, StringListListEntry.StringListCell> createNewInstance;
+    private Function<StringListListEntry, StringListListEntry.StringListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
-    
+
     public StringListBuilder(String resetButtonKey, String fieldNameKey, List<String> value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     public Function<String, Optional<String>> getCellErrorSupplier() {
         return cellErrorSupplier;
     }
-    
+
     public StringListBuilder setCellErrorSupplier(Function<String, Optional<String>> cellErrorSupplier) {
         this.cellErrorSupplier = cellErrorSupplier;
         return this;
     }
-    
+
     public StringListBuilder setErrorSupplier(Function<List<String>, Optional<String>> errorSupplier) {
         this.errorSupplier = errorSupplier;
         return this;
     }
-    
+
     public StringListBuilder setDeleteButtonEnabled(boolean deleteButtonEnabled) {
         this.deleteButtonEnabled = deleteButtonEnabled;
         return this;
     }
-    
+
     public StringListBuilder setInsertInFront(boolean insertInFront) {
         this.insertInFront = insertInFront;
         return this;
     }
-    
+
     public StringListBuilder setAddButtonTooltip(String addTooltip) {
         this.addTooltip = addTooltip;
         return this;
     }
-    
+
     public StringListBuilder setRemoveButtonTooltip(String removeTooltip) {
         this.removeTooltip = removeTooltip;
         return this;
     }
-    
+
     public StringListBuilder requireRestart() {
         requireRestart(true);
         return this;
     }
-    
-    public StringListBuilder setCreateNewInstance(Function<BaseListEntry, StringListListEntry.StringListCell> createNewInstance) {
+
+    public StringListBuilder setCreateNewInstance(Function<StringListListEntry, StringListListEntry.StringListCell> createNewInstance) {
         this.createNewInstance = createNewInstance;
         return this;
     }
-    
+
     public StringListBuilder setExpended(boolean expended) {
         this.expended = expended;
         return this;
     }
-    
+
     public StringListBuilder setSaveConsumer(Consumer<List<String>> saveConsumer) {
         this.saveConsumer = saveConsumer;
         return this;
     }
-    
+
     public StringListBuilder setDefaultValue(Supplier<List<String>> defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
-    
+
     public StringListBuilder setDefaultValue(List<String> defaultValue) {
         this.defaultValue = () -> defaultValue;
         return this;
     }
-    
+
     public StringListBuilder setTooltipSupplier(Supplier<Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = list -> tooltipSupplier.get();
         return this;
     }
-    
+
     public StringListBuilder setTooltipSupplier(Function<List<String>, Optional<String[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public StringListBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public StringListBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     @Override
     public StringListListEntry build() {
         StringListListEntry entry = new StringListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart());
@@ -123,5 +122,5 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
@@ -113,7 +113,7 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
     @NotNull
     @Override
     public StringListListEntry build() {
-        StringListListEntry entry = new StringListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart());
+        StringListListEntry entry = new StringListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart(), deleteButtonEnabled, insertInFront);
         if (createNewInstance != null)
             entry.setCreateNewInstance(createNewInstance);
         entry.setCellErrorSupplier(cellErrorSupplier);

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
@@ -2,6 +2,7 @@ package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.StringListListEntry;
 import net.minecraft.client.resource.language.I18n;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +16,7 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
     private Consumer<List<String>> saveConsumer = null;
     private Function<List<String>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
     private List<String> value;
-    private boolean expended = false;
+    private boolean expanded = false;
     private Function<StringListListEntry, StringListListEntry.StringListCell> createNewInstance;
     private String addTooltip = I18n.translate("text.cloth-config.list.add"), removeTooltip = I18n.translate("text.cloth-config.list.remove");
     private boolean deleteButtonEnabled = true, insertInFront = true;
@@ -69,8 +70,8 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
         return this;
     }
 
-    public StringListBuilder setExpended(boolean expended) {
-        this.expended = expended;
+    public StringListBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
 
@@ -109,9 +110,10 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
         return this;
     }
 
+    @NotNull
     @Override
     public StringListListEntry build() {
-        StringListListEntry entry = new StringListListEntry(getFieldNameKey(), value, expended, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart());
+        StringListListEntry entry = new StringListListEntry(getFieldNameKey(), value, expanded, null, saveConsumer, defaultValue, getResetButtonKey(), isRequireRestart());
         if (createNewInstance != null)
             entry.setCreateNewInstance(createNewInstance);
         entry.setCellErrorSupplier(cellErrorSupplier);

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/SubCategoryBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/SubCategoryBuilder.java
@@ -3,6 +3,7 @@ package me.shedaniel.clothconfig2.impl.builders;
 import com.google.common.collect.Lists;
 import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
 import me.shedaniel.clothconfig2.gui.entries.SubCategoryListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Function;
@@ -12,7 +13,7 @@ public class SubCategoryBuilder extends FieldBuilder<Object, SubCategoryListEntr
     
     private List<AbstractConfigListEntry> entries;
     private Function<List<AbstractConfigListEntry>, Optional<String[]>> tooltipSupplier = list -> Optional.empty();
-    private boolean expended = false;
+    private boolean expanded = false;
     
     public SubCategoryBuilder(String resetButtonKey, String fieldNameKey) {
         super(resetButtonKey, fieldNameKey);
@@ -33,29 +34,30 @@ public class SubCategoryBuilder extends FieldBuilder<Object, SubCategoryListEntr
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public SubCategoryBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = list -> tooltip;
         return this;
     }
-    
+
     public SubCategoryBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
         return this;
     }
-    
-    public SubCategoryBuilder setExpended(boolean expended) {
-        this.expended = expended;
+
+    public SubCategoryBuilder setExpanded(boolean expanded) {
+        this.expanded = expanded;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public SubCategoryListEntry build() {
-        SubCategoryListEntry entry = new SubCategoryListEntry(getFieldNameKey(), entries, expended);
+        SubCategoryListEntry entry = new SubCategoryListEntry(getFieldNameKey(), entries, expanded);
         entry.setTooltipSupplier(() -> tooltipSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
     @Override
     public int size() {
         return entries.size();

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextDescriptionBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextDescriptionBuilder.java
@@ -1,22 +1,24 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.TextListEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 public class TextDescriptionBuilder extends FieldBuilder<String, TextListEntry> {
-    
+
     private int color = -1;
-    @Nullable private Supplier<Optional<String[]>> tooltipSupplier = null;
+    @Nullable
+    private Supplier<Optional<String[]>> tooltipSupplier = null;
     private String value;
-    
+
     public TextDescriptionBuilder(String resetButtonKey, String fieldNameKey, String value) {
         super(resetButtonKey, fieldNameKey);
         this.value = value;
     }
-    
+
     @Override
     public void requireRestart(boolean requireRestart) {
         throw new UnsupportedOperationException();
@@ -31,20 +33,21 @@ public class TextDescriptionBuilder extends FieldBuilder<String, TextListEntry> 
         this.tooltipSupplier = () -> tooltip;
         return this;
     }
-    
+
     public TextDescriptionBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = () -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
     public TextDescriptionBuilder setColor(int color) {
         this.color = color;
         return this;
     }
-    
+
+    @NotNull
     @Override
     public TextListEntry build() {
         return new TextListEntry(getFieldNameKey(), value, color, tooltipSupplier);
     }
-    
+
 }

--- a/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextFieldBuilder.java
+++ b/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextFieldBuilder.java
@@ -1,6 +1,7 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.StringListEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -54,17 +55,18 @@ public class TextFieldBuilder extends FieldBuilder<String, StringListEntry> {
         this.tooltipSupplier = tooltipSupplier;
         return this;
     }
-    
+
     public TextFieldBuilder setTooltip(Optional<String[]> tooltip) {
         this.tooltipSupplier = str -> tooltip;
         return this;
     }
-    
+
     public TextFieldBuilder setTooltip(String... tooltip) {
         this.tooltipSupplier = str -> Optional.ofNullable(tooltip);
         return this;
     }
-    
+
+    @NotNull
     @Override
     public StringListEntry build() {
         StringListEntry entry = new StringListEntry(getFieldNameKey(), value, getResetButtonKey(), defaultValue, saveConsumer, null, isRequireRestart());
@@ -73,5 +75,5 @@ public class TextFieldBuilder extends FieldBuilder<String, StringListEntry> {
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         return entry;
     }
-    
+
 }


### PR DESCRIPTION
Closes #21

Todo:
- [x] Generify a whole lot of stuff
- [x] Create common ancestor for list options
- [x] Migrate current list options to the common ancestor
- [x] Create common ancestor for single-`TextFieldWidget` options
- [x] Migrate applicable list options to the single-`TextFieldWidget` ancestor
- [x] Create new list option for `List<Object>` ~that takes a widget creator function for arbitrary structures~ Didn't bother since AutoConfig modifies in-place anyway. We'll fix it in a v3 rewrite or something.