### PR TITLE
Fix non-standard package naming

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -69,9 +69,9 @@ processResources {
 }
 
 shadowJar {
-    relocate "blue.endless.jankson", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.blue.endless.jankson"
-    relocate "com.moandjiezana.toml", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.com.moandjiezana.toml"
-    relocate "org.yaml.snakeyaml", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.org.yaml.snakeyaml"
+    relocate "blue.endless.jankson", "${rootProject.maven_group}.clothconfig2.shadowed.blue.endless.jankson"
+    relocate "com.moandjiezana.toml", "${rootProject.maven_group}.clothconfig2.shadowed.com.moandjiezana.toml"
+    relocate "org.yaml.snakeyaml", "${rootProject.maven_group}.clothconfig2.shadowed.org.yaml.snakeyaml"
     
     configurations = [project.configurations.shadow]
     classifier "shadow"

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -55,9 +55,9 @@ processResources {
 shadowJar {
     exclude "fabric.mod.json"
     exclude "cloth-config.accessWidener"
-    relocate "blue.endless.jankson", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.blue.endless.jankson"
-    relocate "com.moandjiezana.toml", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.com.moandjiezana.toml"
-    relocate "org.yaml.snakeyaml", "${rootProject.maven_group}.${rootProject.archives_base_name}.shadowed.org.yaml.snakeyaml"
+    relocate "blue.endless.jankson", "${rootProject.maven_group}.clothconfig2.shadowed.blue.endless.jankson"
+    relocate "com.moandjiezana.toml", "${rootProject.maven_group}.clothconfig2.shadowed.com.moandjiezana.toml"
+    relocate "org.yaml.snakeyaml", "${rootProject.maven_group}.clothconfig2.shadowed.org.yaml.snakeyaml"
 
     configurations = [project.configurations.shadow]
     classifier "shadow"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     repositories {
         jcenter()
         maven { url "https://maven.fabricmc.net/" }
-        maven { url "https://dl.bintray.com/shedaniel/cloth" }
+        maven { url "https://maven.shedaniel.me" }
         maven { url "https://files.minecraftforge.net/maven/" }
         maven { url "https://jitpack.io" }
         gradlePluginPortal()


### PR DESCRIPTION
This PR moves shadowed packages from the illegal package name `me.shedaniel.cloth.cloth-config` to the more sensible `me.shedaniel.cloth.clothconfig2`.

This fixes #77.

I've also migrated to your new maven because Bintray is shutting down later this year.