### PR TITLE
Refactor slider widgets to share a common base class, add int and long slider lists

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -107,6 +107,132 @@ public class DefaultGuiProviders {
         );
         
         registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startIntSliderList(
+                        new TranslatableComponent(i13n),
+                        getUnsafely(field, config, Collections.emptyList()),
+                        (int) bounds.min(),
+                        (int) bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                        .build()
+                );
+            },
+            isListOfType(Integer.class),
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startIntSliderList(
+                        new TranslatableComponent(i13n),
+                        Lists.newArrayList(getUnsafely(field, config, new Integer[0])),
+                        (int) bounds.min(),
+                        (int) bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue.toArray(new Integer[0])))
+                        .build()
+                );
+            },
+            field -> field.getType() == Integer[].class,
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startIntSliderList(
+                        new TranslatableComponent(i13n),
+                        Arrays.stream(getUnsafely(field, config, new int[0])).boxed().collect(Collectors.toList()),
+                        (int) bounds.min(),
+                        (int) bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue.stream().mapToInt(Integer::intValue).toArray()))
+                        .build()
+                );
+            },
+            field -> field.getType() == int[].class,
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startLongSliderList(
+                        new TranslatableComponent(i13n),
+                        getUnsafely(field, config, Collections.emptyList()),
+                        bounds.min(),
+                        bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                        .build()
+                );
+            },
+            isListOfType(Long.class),
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startLongSliderList(
+                        new TranslatableComponent(i13n),
+                        Lists.newArrayList(getUnsafely(field, config, new Long[0])),
+                        bounds.min(),
+                        bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue.toArray(new Long[0])))
+                        .build()
+                );
+            },
+            field -> field.getType() == Long[].class,
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
+            (i13n, field, config, defaults, guiProvider) -> {
+                ConfigEntry.BoundedDiscrete bounds
+                    = field.getAnnotation(ConfigEntry.BoundedDiscrete.class);
+
+                return Collections.singletonList(
+                    ENTRY_BUILDER.startLongSliderList(
+                        new TranslatableComponent(i13n),
+                        Arrays.stream(getUnsafely(field, config, new long[0])).boxed().collect(Collectors.toList()),
+                        bounds.min(),
+                        bounds.max()
+                    )
+                        .setDefaultValue(() -> getUnsafely(field, defaults))
+                        .setSaveConsumer(newValue -> setUnsafely(field, config, newValue.stream().mapToLong(Long::longValue).toArray()))
+                        .build()
+                );
+            },
+            field -> field.getType() == long[].class,
+            ConfigEntry.BoundedDiscrete.class
+        );
+
+        registry.registerAnnotationProvider(
                 (i13n, field, config, defaults, guiProvider) -> {
                     ConfigEntry.ColorPicker colorPicker
                             = field.getAnnotation(ConfigEntry.ColorPicker.class);

--- a/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
@@ -112,6 +112,14 @@ public class ClothConfigDemo {
         innerColors.add(innerInnerColors.build());
         colors.add(innerColors.build());
         testing.addEntry(colors.build());
+
+        SubCategoryBuilder sliders = entryBuilder.startSubCategory(new TextComponent("Sliders")).setExpanded(true);
+        sliders.add(entryBuilder.startIntSlider(new TextComponent("Int Slider"), 50, 0, 100).setDefaultValue(0).build());
+        sliders.add(entryBuilder.startLongSlider(new TextComponent("Long Slider"), 10_000_000_050l, 10_000_000_000l, 10_000_000_100l).setDefaultValue(10_000_000_020l).build());
+        sliders.add(entryBuilder.startIntSliderList(new TextComponent("Int Slider List"), Lists.newArrayList(0, 25, 50, 75, 100), 0, 100).setDefaultValue(Lists.newArrayList(50)).setCellDefaultValue(80).setTextGetter(value -> new TextComponent(value + "%")).setSaveConsumer(list -> System.out.println("check out this list " + list)).build());
+        sliders.add(entryBuilder.startLongSliderList(new TextComponent("Long Slider List"), Lists.newArrayList(10_000_000_050l), 10_000_000_000l, 10_000_000_100l).setDefaultValue(Lists.newArrayList(10_000_000_020l)).setCellDefaultValue(10_000_000_080l).setSaveConsumer(list -> System.out.println("check out this long list " + list)).build());
+        testing.addEntry(sliders.build());
+
         testing.addEntry(entryBuilder.startDropdownMenu(new TextComponent("Suggestion Random Int"), DropdownMenuBuilder.TopCellElementBuilder.of(10,
                 s -> {
                     try {

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
@@ -103,8 +103,12 @@ public interface ConfigEntryBuilder {
     
     IntSliderBuilder startIntSlider(Component fieldNameKey, int value, int min, int max);
     
+    IntSliderListBuilder startIntSliderList(Component fieldNameKey, List<Integer> value, int min, int max);
+
     LongSliderBuilder startLongSlider(Component fieldNameKey, long value, long min, long max);
     
+    LongSliderListBuilder startLongSliderList(Component fieldNameKey, List<Long> value, long min, long max);
+
     KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value);
     
     default KeyCodeBuilder startKeyCodeField(Component fieldNameKey, InputConstants.Key value) {

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderEntry.java
@@ -19,20 +19,18 @@
 
 package me.shedaniel.clothconfig2.gui.entries;
 
+import me.shedaniel.clothconfig2.gui.widget.ManagedSliderWidget;
+
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.chat.NarratorChatListener;
-import net.minecraft.client.gui.components.AbstractSliderButton;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Mth;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
@@ -42,11 +40,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A config entry containing a single bounded value with an
- * {@link AbstractSliderButton} for user display and input.
+ * {@link ManagedSliderWidget} for user display and input.
  *
  * Any bounded value that can be respresented as a {@code double} can be
  * managed by subclassing this class and implementing the
@@ -59,9 +55,7 @@ import static java.util.Objects.requireNonNull;
  */
 @Environment(EnvType.CLIENT)
 public abstract class AbstractSliderEntry<T, SELF extends AbstractSliderEntry<T, SELF>> extends TooltipListEntry<T> {
-    private static final ResourceLocation WIDGETS_TEX = new ResourceLocation("textures/gui/widgets.png");
-
-    protected Slider sliderWidget;
+    protected ManagedSliderWidget sliderWidget;
     protected Button resetButton;
     protected final T original;
     protected T minimum, maximum;
@@ -78,7 +72,7 @@ public abstract class AbstractSliderEntry<T, SELF extends AbstractSliderEntry<T,
         this.saveConsumer = saveConsumer;
         this.maximum = maximum;
         this.minimum = minimum;
-        this.sliderWidget = new Slider(0, 0, 152, 20, 0);
+        this.sliderWidget = new ManagedSliderWidget(0, 0, 152, 20, AbstractSliderEntry.this.sliderContext());
         this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
             setValue(defaultValue.get());
             syncValueToSlider();
@@ -95,7 +89,7 @@ public abstract class AbstractSliderEntry<T, SELF extends AbstractSliderEntry<T,
     protected abstract void setValueFromSlider(double value);
 
     protected void syncValueToSlider() {
-        sliderWidget.syncValueFromEntry();
+        sliderWidget.syncValueFromContext();
     }
 
     protected Component getValueForMessage() {
@@ -160,63 +154,23 @@ public abstract class AbstractSliderEntry<T, SELF extends AbstractSliderEntry<T,
         sliderWidget.render(matrices, mouseX, mouseY, delta);
     }
 
-    private class Slider extends AbstractSliderButton {
-        protected Slider(int x, int y, int width, int height, double value) {
-            super(x, y, width, height, NarratorChatListener.NO_TITLE, value);
-        }
-
-        protected void syncValueFromEntry() {
-            this.value = AbstractSliderEntry.this.getValueForSlider();
-            updateMessage();
-        }
-
-        @Override
-        public void updateMessage() {
-            if (AbstractSliderEntry.this.textGetter != null) {
-                setMessage(AbstractSliderEntry.this.getValueForMessage());
-            }
-        }
-
-        @Override
-        protected void applyValue() {
-            AbstractSliderEntry.this.setValueFromSlider(value);
-        }
-
-        @Override
-        public boolean keyPressed(int keyCode, int int_2, int int_3) {
-            if (!isEditable())
-                return false;
-            return super.keyPressed(keyCode, int_2, int_3);
-        }
-
-        @Override
-        public boolean mouseDragged(double mouseX, double mouseY, int mouseButton, double deltaX, double deltaY) {
-            if (!isEditable())
-                return false;
-            return super.mouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
-        }
-
-        @Override
-        protected void renderBg(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
-            /*
-             * If the width is greater than 200, then fill in the gap in the middle with more button bg
-             */
-            int gap = width - 200;
-            if (gap > 0) {
-                client.getTextureManager().bind(WIDGETS_TEX);
-
-                int offset = 100;
-                do {
-                    blit(matrices, x + offset, y, 1, 46 + 0 * 20, Math.min(gap, 198), height);
-
-                    offset += 198;
-                    gap -= 198;
-                } while (gap > 0);
+    private ManagedSliderWidget.Context sliderContext() {
+        return new ManagedSliderWidget.Context() {
+            public Component message() {
+                return getValueForMessage();
             }
 
-            // Render the scrubber on top of anything we've drawn
-            super.renderBg(matrices, client, mouseX, mouseY);
-        }
+            public double value() {
+                return getValueForSlider();
+            }
 
+            public void valueApplied(double value) {
+                setValueFromSlider(value);
+            }
+
+            public boolean editable() {
+                return isEditable();
+            }
+        };
     }
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderEntry.java
@@ -1,0 +1,222 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.clothconfig2.gui.entries;
+
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.chat.NarratorChatListener;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A config entry containing a single bounded value with an
+ * {@link AbstractSliderButton} for user display and input.
+ *
+ * Any bounded value that can be respresented as a {@code double} can be
+ * managed by subclassing this class and implementing the
+ * {@link #getValueForSlider()} and {@link #setValueFromSlider(double)}
+ * methods.
+ *
+ * @param <T>    the configuration object type
+ * @param <SELF> the "curiously recurring template pattern" type parameter
+ * @see TooltipListEntry
+ */
+@Environment(EnvType.CLIENT)
+public abstract class AbstractSliderEntry<T, SELF extends AbstractSliderEntry<T, SELF>> extends TooltipListEntry<T> {
+    private static final ResourceLocation WIDGETS_TEX = new ResourceLocation("textures/gui/widgets.png");
+
+    protected Slider sliderWidget;
+    protected Button resetButton;
+    protected final T original;
+    protected T minimum, maximum;
+    private final Consumer<T> saveConsumer;
+    private final Supplier<T> defaultValue;
+    private Function<T, Component> textGetter = integer -> new TextComponent(String.format("Value: %d", integer));
+    private final List<GuiEventListener> widgets;
+
+    @ApiStatus.Internal
+    public AbstractSliderEntry(Component fieldName, T minimum, T maximum, T value, Component resetButtonKey, Supplier<T> defaultValue, Consumer<T> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
+        super(fieldName, tooltipSupplier, requiresRestart);
+        this.original = value;
+        this.defaultValue = defaultValue;
+        this.saveConsumer = saveConsumer;
+        this.maximum = maximum;
+        this.minimum = minimum;
+        this.sliderWidget = new Slider(0, 0, 152, 20, 0);
+        this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
+            setValue(defaultValue.get());
+            syncValueToSlider();
+        });
+        this.widgets = Lists.newArrayList(sliderWidget, resetButton);
+    }
+
+    abstract protected SELF self();
+
+    protected abstract void setValue(T value);
+
+    protected abstract double getValueForSlider();
+
+    protected abstract void setValueFromSlider(double value);
+
+    protected void syncValueToSlider() {
+        sliderWidget.syncValueFromEntry();
+    }
+
+    protected Component getValueForMessage() {
+        if (textGetter == null) {
+            return null;
+        } else {
+            return textGetter.apply(getValue());
+        }
+    }
+
+    @Override
+    public void save() {
+        if (saveConsumer != null)
+            saveConsumer.accept(getValue());
+    }
+
+    public Function<T, Component> getTextGetter() {
+        return textGetter;
+    }
+
+    public SELF setTextGetter(Function<T, Component> textGetter) {
+        this.textGetter = textGetter;
+        this.sliderWidget.updateMessage();
+        return self();
+    }
+
+    @Override
+    public boolean isEdited() {
+        return super.isEdited() || !Objects.equals(getValue(), original);
+    }
+
+    @Override
+    public Optional<T> getDefaultValue() {
+        return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
+    }
+
+    @Override
+    public List<? extends GuiEventListener> children() {
+        return widgets;
+    }
+
+    @Override
+    public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
+        super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
+        Window window = Minecraft.getInstance().getWindow();
+        this.resetButton.active = isEditable() && getDefaultValue().isPresent() && !Objects.equals(defaultValue.get(), getValue());
+        this.resetButton.y = y;
+        this.sliderWidget.active = isEditable();
+        this.sliderWidget.y = y;
+        Component displayedFieldName = getDisplayedFieldName();
+        if (Minecraft.getInstance().font.isBidirectional()) {
+            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), window.getGuiScaledWidth() - x - Minecraft.getInstance().font.width(displayedFieldName), y + 6, getPreferredTextColor());
+            this.resetButton.x = x;
+            this.sliderWidget.x = x + resetButton.getWidth() + 1;
+        } else {
+            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), x, y + 6, getPreferredTextColor());
+            this.resetButton.x = x + entryWidth - resetButton.getWidth();
+            this.sliderWidget.x = x + entryWidth - 150;
+        }
+        this.sliderWidget.setWidth(150 - resetButton.getWidth() - 2);
+        resetButton.render(matrices, mouseX, mouseY, delta);
+        sliderWidget.render(matrices, mouseX, mouseY, delta);
+    }
+
+    private class Slider extends AbstractSliderButton {
+        protected Slider(int x, int y, int width, int height, double value) {
+            super(x, y, width, height, NarratorChatListener.NO_TITLE, value);
+        }
+
+        protected void syncValueFromEntry() {
+            this.value = AbstractSliderEntry.this.getValueForSlider();
+            updateMessage();
+        }
+
+        @Override
+        public void updateMessage() {
+            if (AbstractSliderEntry.this.textGetter != null) {
+                setMessage(AbstractSliderEntry.this.getValueForMessage());
+            }
+        }
+
+        @Override
+        protected void applyValue() {
+            AbstractSliderEntry.this.setValueFromSlider(value);
+        }
+
+        @Override
+        public boolean keyPressed(int keyCode, int int_2, int int_3) {
+            if (!isEditable())
+                return false;
+            return super.keyPressed(keyCode, int_2, int_3);
+        }
+
+        @Override
+        public boolean mouseDragged(double mouseX, double mouseY, int mouseButton, double deltaX, double deltaY) {
+            if (!isEditable())
+                return false;
+            return super.mouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
+        }
+
+        @Override
+        protected void renderBg(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
+            /*
+             * If the width is greater than 200, then fill in the gap in the middle with more button bg
+             */
+            int gap = width - 200;
+            if (gap > 0) {
+                client.getTextureManager().bind(WIDGETS_TEX);
+
+                int offset = 100;
+                do {
+                    blit(matrices, x + offset, y, 1, 46 + 0 * 20, Math.min(gap, 198), height);
+
+                    offset += 198;
+                    gap -= 198;
+                } while (gap > 0);
+            }
+
+            // Render the scrubber on top of anything we've drawn
+            super.renderBg(matrices, client, mouseX, mouseY);
+        }
+
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderListEntry.java
@@ -1,0 +1,197 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.chat.NarratorChatListener;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A config entry list consisting of bounded values that use one
+ * {@link AbstractSliderListCell} per entry.
+ *
+ * Any bounded values that can be respresented as a {@code double} can be
+ * listed using this entry list by implementing a specialized subclass of
+ * {@link AbstractSliderListCell}.
+ *
+ * @param <T>    the configuration object type
+ * @param <C>    the cell type
+ * @param <SELF> the "curiously recurring template pattern" type parameter
+ * @see AbstractListListEntry
+ */
+@Environment(EnvType.CLIENT)
+public abstract class AbstractSliderListEntry<T, C extends AbstractSliderListEntry.AbstractSliderListCell<T, C, SELF>, SELF extends AbstractSliderListEntry<T, C, SELF>> extends AbstractListListEntry<T, C, SELF> {
+    private static final ResourceLocation WIDGETS_TEX = new ResourceLocation("textures/gui/widgets.png");
+
+    protected final T minimum, maximum, cellDefaultValue;
+    protected Function<T, Component> textGetter;
+
+    public AbstractSliderListEntry(Component fieldName, T minimum, T maximum, List<T> value, boolean defaultExpanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, T cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront, BiFunction<T, SELF, C> createNewCell) {
+        super(fieldName, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, createNewCell);
+
+        this.minimum = requireNonNull(minimum);
+        this.maximum = requireNonNull(maximum);
+        this.cellDefaultValue = requireNonNull(cellDefaultValue);
+    }
+
+    public SELF setTextGetter(Function<T, Component> textGetter) {
+        this.textGetter = textGetter;
+        this.cells.forEach(c -> c.sliderWidget.updateMessage());
+        return self();
+    }
+
+    /**
+     * A config entry within a parent {@link AbstractSliderListEntry}
+     * containing a single bounded value with an {@link AbstractSliderButton}
+     * for user display and input.
+     *
+     * Any bounded value that can be respresented as a {@code double} can be
+     * listed by subclassing this class and its parent {@link AbstractSliderListEntry},
+     * implementing the {@link #getValueForSlider()} and
+     * {@link #setValueFromSlider(double)} methods.
+     *
+     * @param <T>          the configuration object type
+     * @param <SELF>       the "curiously recurring template pattern" type parameter for this class
+     * @param <OUTER_SELF> the "curiously recurring template pattern" type parameter for the outer class
+     * @see AbstractSliderListEntry
+     */
+    public abstract static class AbstractSliderListCell<T, SELF extends AbstractSliderListEntry.AbstractSliderListCell<T, SELF, OUTER_SELF>, OUTER_SELF extends AbstractSliderListEntry<T, SELF, OUTER_SELF>> extends AbstractListListEntry.AbstractListCell<T, SELF, OUTER_SELF> {
+        protected final Slider sliderWidget;
+        private boolean isSelected;
+
+        public AbstractSliderListCell(T value, OUTER_SELF listListEntry) {
+            super(value, listListEntry);
+            this.sliderWidget = new Slider(0, 0, 152, 20, 0);
+        }
+
+        protected abstract double getValueForSlider();
+
+        protected abstract void setValueFromSlider(double value);
+
+        protected void syncValueToSlider() {
+            sliderWidget.syncValueFromCell();
+        }
+
+        protected Component getValueForMessage() {
+            if (listListEntry.textGetter == null) {
+                return null;
+            } else {
+                return listListEntry.textGetter.apply(getValue());
+            }
+        }
+
+        @Override
+        public void onAdd() {
+            syncValueToSlider();
+            sliderWidget.updateMessage();
+        }
+
+        @Override
+        public void updateSelected(boolean isSelected) {
+            this.isSelected = isSelected;
+        }
+
+        @Override
+        public Optional<Component> getError() {
+            return Optional.empty();
+        }
+
+        @Override
+        public int getCellHeight() {
+            return 22;
+        }
+
+        @Override
+        public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isFocusedCell, float delta) {
+            sliderWidget.x = x;
+            sliderWidget.y = y;
+            sliderWidget.setWidth(entryWidth - 12);
+            sliderWidget.active = listListEntry.isEditable();
+            sliderWidget.render(matrices, mouseX, mouseY, delta);
+        }
+
+        @Override
+        public List<? extends GuiEventListener> children() {
+            return Collections.singletonList(sliderWidget);
+        }
+
+        private class Slider extends AbstractSliderButton {
+            protected Slider(int x, int y, int width, int height, double value) {
+                super(x, y, width, height, NarratorChatListener.NO_TITLE, value);
+            }
+
+            protected void syncValueFromCell() {
+                this.value = AbstractSliderListCell.this.getValueForSlider();
+                updateMessage();
+            }
+
+            @Override
+            public void updateMessage() {
+                if (AbstractSliderListCell.this.listListEntry.textGetter != null) {
+                    setMessage(AbstractSliderListCell.this.getValueForMessage());
+                }
+            }
+
+            @Override
+            protected void applyValue() {
+                AbstractSliderListCell.this.setValueFromSlider(value);
+            }
+
+            @Override
+            public boolean keyPressed(int keyCode, int int_2, int int_3) {
+                if (!listListEntry.isEditable())
+                    return false;
+                return super.keyPressed(keyCode, int_2, int_3);
+            }
+
+            @Override
+            public boolean mouseDragged(double mouseX, double mouseY, int mouseButton, double deltaX, double deltaY) {
+                if (!listListEntry.isEditable())
+                    return false;
+                return super.mouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
+            }
+
+            @Override
+            protected void renderBg(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
+                /*
+                 * If the width is greater than 200, then fill in the gap in the middle with more button bg
+                 */
+                int gap = width - 200;
+                if (gap > 0) {
+                    client.getTextureManager().bind(WIDGETS_TEX);
+
+                    int offset = 100;
+                    do {
+                        blit(matrices, x + offset, y, 1, 46 + 0 * 20, Math.min(gap, 198), height);
+
+                        offset += 198;
+                        gap -= 198;
+                    } while (gap > 0);
+                }
+
+                // Note: the non-error highlight color here is a bit darker
+                // than the normal highlight of 0xffe0e0e0 to let the scrubber stand out
+                if (isSelected && listListEntry.isEditable())
+                    fill(matrices, x, y + 19, x + width, y + 20, getConfigError().isPresent() ? 0xffff5555 : 0xffa0a0a0);
+
+                // Render the scrubber on top of anything we've drawn
+                super.renderBg(matrices, client, mouseX, mouseY);
+            }
+        }
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractSliderListEntry.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.gui.entries;
 
 import me.shedaniel.clothconfig2.gui.widget.ManagedSliderWidget;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -278,7 +278,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         if (expanded) {
             int yy = y + 24;
             for (BaseListCell cell : cells) {
-                cell.render(matrices, -1, yy, x + 14, entryWidth - 14, cell.getCellHeight(), mouseX, mouseY, getParent().getFocused() != null && getParent().getFocused().equals(this) && getFocused() != null && getFocused().equals(cell), delta);
+                cell.render(matrices, -1, yy, x + 14, entryWidth - 14, cell.getCellHeight(), mouseX, mouseY, Objects.equals(getParent().getFocused(), this) && Objects.equals(getFocused(), cell), delta);
                 yy += cell.getCellHeight();
             }
         }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
@@ -19,41 +19,25 @@
 
 package me.shedaniel.clothconfig2.gui.entries;
 
-import com.google.common.collect.Lists;
-import com.mojang.blaze3d.platform.Window;
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.chat.NarratorChatListener;
-import net.minecraft.client.gui.components.AbstractSliderButton;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.util.Mth;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * A config entry containing a single bounded {@link Integer} with an
+ * {@link net.minecraft.client.gui.components.AbstractSliderButton} for
+ * user display and input.
+ */
 @Environment(EnvType.CLIENT)
-public class IntegerSliderEntry extends TooltipListEntry<Integer> {
-    
-    protected Slider sliderWidget;
-    protected Button resetButton;
+public class IntegerSliderEntry extends AbstractSliderEntry<Integer, IntegerSliderEntry> {
     protected AtomicInteger value;
-    protected final long orginial;
-    private int minimum, maximum;
-    private final Consumer<Integer> saveConsumer;
-    private final Supplier<Integer> defaultValue;
-    private Function<Integer, Component> textGetter = integer -> new TextComponent(String.format("Value: %d", integer));
-    private final List<GuiEventListener> widgets;
-    
+
     @ApiStatus.Internal
     @Deprecated
     public IntegerSliderEntry(Component fieldName, int minimum, int maximum, int value, Component resetButtonKey, Supplier<Integer> defaultValue, Consumer<Integer> saveConsumer) {
@@ -69,137 +53,34 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
     @ApiStatus.Internal
     @Deprecated
     public IntegerSliderEntry(Component fieldName, int minimum, int maximum, int value, Component resetButtonKey, Supplier<Integer> defaultValue, Consumer<Integer> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, requiresRestart);
-        this.orginial = value;
-        this.defaultValue = defaultValue;
+        super(fieldName, minimum, maximum, value, resetButtonKey, defaultValue, saveConsumer, tooltipSupplier, requiresRestart);
+
         this.value = new AtomicInteger(value);
-        this.saveConsumer = saveConsumer;
-        this.maximum = maximum;
-        this.minimum = minimum;
-        this.sliderWidget = new Slider(0, 0, 152, 20, ((double) this.value.get() - minimum) / Math.abs(maximum - minimum));
-        this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
-            setValue(defaultValue.get());
-        });
-        this.sliderWidget.setMessage(textGetter.apply(IntegerSliderEntry.this.value.get()));
-        this.widgets = Lists.newArrayList(sliderWidget, resetButton);
+        syncValueToSlider();
     }
-    
+
     @Override
-    public void save() {
-        if (saveConsumer != null)
-            saveConsumer.accept(getValue());
-    }
-    
-    public Function<Integer, Component> getTextGetter() {
-        return textGetter;
-    }
-    
-    public IntegerSliderEntry setTextGetter(Function<Integer, Component> textGetter) {
-        this.textGetter = textGetter;
-        this.sliderWidget.setMessage(textGetter.apply(IntegerSliderEntry.this.value.get()));
+    protected IntegerSliderEntry self() {
         return this;
     }
-    
+
     @Override
     public Integer getValue() {
         return value.get();
     }
-    
-    @Deprecated
-    public void setValue(int value) {
-        sliderWidget.setValue((Mth.clamp(value, minimum, maximum) - minimum) / (double) Math.abs(maximum - minimum));
-        this.value.set(Math.min(Math.max(value, minimum), maximum));
-        sliderWidget.updateMessage();
-    }
-    
+
     @Override
-    public boolean isEdited() {
-        return super.isEdited() || getValue() != orginial;
+    protected void setValue(Integer value) {
+        this.value.set(value);
     }
-    
+
     @Override
-    public Optional<Integer> getDefaultValue() {
-        return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
+    protected double getValueForSlider() {
+        return ((double) this.value.get() - minimum) / Math.abs(maximum - minimum);
     }
-    
+
     @Override
-    public List<? extends GuiEventListener> children() {
-        return widgets;
+    protected void setValueFromSlider(double value) {
+        this.value.set((int) (minimum + Math.abs(maximum - minimum) * value));
     }
-    
-    public IntegerSliderEntry setMaximum(int maximum) {
-        this.maximum = maximum;
-        return this;
-    }
-    
-    public IntegerSliderEntry setMinimum(int minimum) {
-        this.minimum = minimum;
-        return this;
-    }
-    
-    @Override
-    public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
-        super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
-        Window window = Minecraft.getInstance().getWindow();
-        this.resetButton.active = isEditable() && getDefaultValue().isPresent() && defaultValue.get() != value.get();
-        this.resetButton.y = y;
-        this.sliderWidget.active = isEditable();
-        this.sliderWidget.y = y;
-        Component displayedFieldName = getDisplayedFieldName();
-        if (Minecraft.getInstance().font.isBidirectional()) {
-            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), window.getGuiScaledWidth() - x - Minecraft.getInstance().font.width(displayedFieldName), y + 6, getPreferredTextColor());
-            this.resetButton.x = x;
-            this.sliderWidget.x = x + resetButton.getWidth() + 1;
-        } else {
-            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), x, y + 6, getPreferredTextColor());
-            this.resetButton.x = x + entryWidth - resetButton.getWidth();
-            this.sliderWidget.x = x + entryWidth - 150;
-        }
-        this.sliderWidget.setWidth(150 - resetButton.getWidth() - 2);
-        resetButton.render(matrices, mouseX, mouseY, delta);
-        sliderWidget.render(matrices, mouseX, mouseY, delta);
-    }
-    
-    private class Slider extends AbstractSliderButton {
-        protected Slider(int int_1, int int_2, int int_3, int int_4, double double_1) {
-            super(int_1, int_2, int_3, int_4, NarratorChatListener.NO_TITLE, double_1);
-        }
-        
-        @Override
-        public void updateMessage() {
-            setMessage(textGetter.apply(IntegerSliderEntry.this.value.get()));
-        }
-        
-        @Override
-        protected void applyValue() {
-            IntegerSliderEntry.this.value.set((int) (minimum + Math.abs(maximum - minimum) * value));
-        }
-        
-        @Override
-        public boolean keyPressed(int int_1, int int_2, int int_3) {
-            if (!isEditable())
-                return false;
-            return super.keyPressed(int_1, int_2, int_3);
-        }
-        
-        @Override
-        public boolean mouseDragged(double double_1, double double_2, int int_1, double double_3, double double_4) {
-            if (!isEditable())
-                return false;
-            return super.mouseDragged(double_1, double_2, int_1, double_3, double_4);
-        }
-        
-        public double getProgress() {
-            return value;
-        }
-        
-        public void setProgress(double integer) {
-            this.value = integer;
-        }
-        
-        public void setValue(double integer) {
-            this.value = integer;
-        }
-    }
-    
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderListEntry.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.gui.entries;
 
 import net.fabricmc.api.EnvType;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderListEntry.java
@@ -1,0 +1,65 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A config entry list consisting of bounded {@link Integer} values that use
+ * one {@link IntegerSliderListCell} per entry.
+ */
+@Environment(EnvType.CLIENT)
+public class IntegerSliderListEntry extends AbstractSliderListEntry<Integer, IntegerSliderListEntry.IntegerSliderListCell, IntegerSliderListEntry> {
+    private static final Function<Integer, Component> DEFAULT_TEXT_GETTER = value -> new TextComponent(String.format("Value: %d", value));
+
+    public IntegerSliderListEntry(Component fieldName, int minimum, int maximum, List<Integer> value, boolean defaultExpanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, int cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, minimum, maximum, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, cellDefaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, IntegerSliderListCell::new);
+        setTextGetter(DEFAULT_TEXT_GETTER);
+        cells.forEach(IntegerSliderListCell::syncValueToSlider);
+    }
+
+    @Override
+    public IntegerSliderListEntry self() {
+        return this;
+    }
+
+    /**
+     * A config entry within a parent {@link IntegerSliderListEntry} containing
+     * a single bounded {@link Integer} with an
+     * {@link net.minecraft.client.gui.components.AbstractSliderButton} for
+     * user display and input.
+     */
+    public static class IntegerSliderListCell extends AbstractSliderListEntry.AbstractSliderListCell<Integer, IntegerSliderListCell, IntegerSliderListEntry> {
+        private final AtomicInteger value;
+
+        public IntegerSliderListCell(Integer value, IntegerSliderListEntry listListEntry) {
+            super(value, listListEntry);
+
+            this.value = new AtomicInteger(value == null ? listListEntry.cellDefaultValue : value);
+        }
+
+        @Override
+        public Integer getValue() {
+            return value.get();
+        }
+
+        @Override
+        protected double getValueForSlider() {
+            return ((double) this.value.get() - listListEntry.minimum) / Math.abs(listListEntry.maximum - listListEntry.minimum);
+        }
+
+        @Override
+        protected void setValueFromSlider(double value) {
+            this.value.set((int) (listListEntry.minimum + Math.abs(listListEntry.maximum - listListEntry.minimum) * value));
+        }
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
@@ -19,183 +19,68 @@
 
 package me.shedaniel.clothconfig2.gui.entries;
 
-import com.google.common.collect.Lists;
-import com.mojang.blaze3d.platform.Window;
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.chat.NarratorChatListener;
-import net.minecraft.client.gui.components.AbstractSliderButton;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.util.Mth;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * A config entry containing a single bounded {@link Long} with an
+ * {@link net.minecraft.client.gui.components.AbstractSliderButton} for
+ * user display and input.
+ */
 @Environment(EnvType.CLIENT)
-public class LongSliderEntry extends TooltipListEntry<Long> {
-    
-    protected Slider sliderWidget;
-    protected Button resetButton;
+public class LongSliderEntry extends AbstractSliderEntry<Long, LongSliderEntry> {
     protected AtomicLong value;
-    protected final long orginial;
-    private long minimum, maximum;
-    private final Consumer<Long> saveConsumer;
-    private final Supplier<Long> defaultValue;
-    private Function<Long, Component> textGetter = value -> new TextComponent(String.format("Value: %d", value));
-    private final List<GuiEventListener> widgets;
-    
+
     @ApiStatus.Internal
     @Deprecated
     public LongSliderEntry(Component fieldName, long minimum, long maximum, long value, Consumer<Long> saveConsumer, Component resetButtonKey, Supplier<Long> defaultValue) {
         this(fieldName, minimum, maximum, value, saveConsumer, resetButtonKey, defaultValue, null);
     }
-    
+
     @ApiStatus.Internal
     @Deprecated
     public LongSliderEntry(Component fieldName, long minimum, long maximum, long value, Consumer<Long> saveConsumer, Component resetButtonKey, Supplier<Long> defaultValue, Supplier<Optional<Component[]>> tooltipSupplier) {
         this(fieldName, minimum, maximum, value, saveConsumer, resetButtonKey, defaultValue, tooltipSupplier, false);
     }
-    
+
     @ApiStatus.Internal
     @Deprecated
     public LongSliderEntry(Component fieldName, long minimum, long maximum, long value, Consumer<Long> saveConsumer, Component resetButtonKey, Supplier<Long> defaultValue, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
-        super(fieldName, tooltipSupplier, requiresRestart);
-        this.orginial = value;
-        this.defaultValue = defaultValue;
+        super(fieldName, minimum, maximum, value, resetButtonKey, defaultValue, saveConsumer, tooltipSupplier, requiresRestart);
+
         this.value = new AtomicLong(value);
-        this.saveConsumer = saveConsumer;
-        this.maximum = maximum;
-        this.minimum = minimum;
-        this.sliderWidget = new Slider(0, 0, 152, 20, ((double) LongSliderEntry.this.value.get() - minimum) / Math.abs(maximum - minimum));
-        this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
-            setValue(defaultValue.get());
-        });
-        this.sliderWidget.setMessage(textGetter.apply(LongSliderEntry.this.value.get()));
-        this.widgets = Lists.newArrayList(sliderWidget, resetButton);
+        syncValueToSlider();
     }
-    
+
     @Override
-    public void save() {
-        if (saveConsumer != null)
-            saveConsumer.accept(getValue());
-    }
-    
-    public Function<Long, Component> getTextGetter() {
-        return textGetter;
-    }
-    
-    public LongSliderEntry setTextGetter(Function<Long, Component> textGetter) {
-        this.textGetter = textGetter;
-        this.sliderWidget.setMessage(textGetter.apply(LongSliderEntry.this.value.get()));
+    protected LongSliderEntry self() {
         return this;
     }
-    
+
     @Override
     public Long getValue() {
         return value.get();
     }
-    
-    @Deprecated
-    public void setValue(long value) {
-        sliderWidget.setValue((Mth.clamp(value, minimum, maximum) - minimum) / (double) Math.abs(maximum - minimum));
-        this.value.set(Math.min(Math.max(value, minimum), maximum));
-        sliderWidget.updateMessage();
-    }
-    
+
     @Override
-    public Optional<Long> getDefaultValue() {
-        return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
+    protected void setValue(Long value) {
+        this.value.set(value);
     }
-    
+
     @Override
-    public List<? extends GuiEventListener> children() {
-        return widgets;
+    protected double getValueForSlider() {
+        return ((double) this.value.get() - minimum) / Math.abs(maximum - minimum);
     }
-    
+
     @Override
-    public boolean isEdited() {
-        return super.isEdited() || getValue() != orginial;
+    protected void setValueFromSlider(double value) {
+        this.value.set((long) (minimum + Math.abs(maximum - minimum) * value));
     }
-    
-    public LongSliderEntry setMaximum(long maximum) {
-        this.maximum = maximum;
-        return this;
-    }
-    
-    public LongSliderEntry setMinimum(long minimum) {
-        this.minimum = minimum;
-        return this;
-    }
-    
-    @Override
-    public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
-        super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
-        Window window = Minecraft.getInstance().getWindow();
-        this.resetButton.active = isEditable() && getDefaultValue().isPresent() && defaultValue.get() != value.get();
-        this.resetButton.y = y;
-        this.sliderWidget.active = isEditable();
-        this.sliderWidget.y = y;
-        Component displayedFieldName = getDisplayedFieldName();
-        if (Minecraft.getInstance().font.isBidirectional()) {
-            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), window.getGuiScaledWidth() - x - Minecraft.getInstance().font.width(displayedFieldName), y + 6, getPreferredTextColor());
-            this.resetButton.x = x;
-            this.sliderWidget.x = x + resetButton.getWidth() + 1;
-        } else {
-            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), x, y + 6, getPreferredTextColor());
-            this.resetButton.x = x + entryWidth - resetButton.getWidth();
-            this.sliderWidget.x = x + entryWidth - 150;
-        }
-        this.sliderWidget.setWidth(150 - resetButton.getWidth() - 2);
-        resetButton.render(matrices, mouseX, mouseY, delta);
-        sliderWidget.render(matrices, mouseX, mouseY, delta);
-    }
-    
-    private class Slider extends AbstractSliderButton {
-        protected Slider(int int_1, int int_2, int int_3, int int_4, double double_1) {
-            super(int_1, int_2, int_3, int_4, NarratorChatListener.NO_TITLE, double_1);
-        }
-        
-        @Override
-        public void updateMessage() {
-            setMessage(textGetter.apply(LongSliderEntry.this.value.get()));
-        }
-        
-        @Override
-        protected void applyValue() {
-            LongSliderEntry.this.value.set((long) (minimum + Math.abs(maximum - minimum) * value));
-        }
-        
-        @Override
-        public boolean keyPressed(int int_1, int int_2, int int_3) {
-            if (!isEditable())
-                return false;
-            return super.keyPressed(int_1, int_2, int_3);
-        }
-        
-        @Override
-        public boolean mouseDragged(double double_1, double double_2, int int_1, double double_3, double double_4) {
-            if (!isEditable())
-                return false;
-            return super.mouseDragged(double_1, double_2, int_1, double_3, double_4);
-        }
-        
-        public double getValue() {
-            return value;
-        }
-        
-        public void setValue(double integer) {
-            this.value = integer;
-        }
-    }
-    
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderListEntry.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.gui.entries;
 
 import net.fabricmc.api.EnvType;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderListEntry.java
@@ -1,0 +1,65 @@
+package me.shedaniel.clothconfig2.gui.entries;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A config entry list consisting of bounded {@link Long} values that use one
+ * {@link LongSliderListCell} per entry.
+ */
+@Environment(EnvType.CLIENT)
+public class LongSliderListEntry extends AbstractSliderListEntry<Long, LongSliderListEntry.LongSliderListCell, LongSliderListEntry> {
+    private static final Function<Long, Component> DEFAULT_TEXT_GETTER = value -> new TextComponent(String.format("Value: %d", value));
+
+    public LongSliderListEntry(Component fieldName, long minimum, long maximum, List<Long> value, boolean defaultExpanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, long cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        super(fieldName, minimum, maximum, value, defaultExpanded, tooltipSupplier, saveConsumer, defaultValue, cellDefaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront, LongSliderListCell::new);
+        setTextGetter(DEFAULT_TEXT_GETTER);
+        cells.forEach(LongSliderListCell::syncValueToSlider);
+    }
+
+    @Override
+    public LongSliderListEntry self() {
+        return this;
+    }
+
+    /**
+     * A config entry within a parent {@link LongSliderListEntry} containing a
+     * single bounded {@link Long} with an
+     * {@link net.minecraft.client.gui.components.AbstractSliderButton} for
+     * user display and input.
+     */
+    public static class LongSliderListCell extends AbstractSliderListEntry.AbstractSliderListCell<Long, LongSliderListCell, LongSliderListEntry> {
+        private final AtomicLong value;
+
+        public LongSliderListCell(Long value, LongSliderListEntry listListEntry) {
+            super(value, listListEntry);
+
+            this.value = new AtomicLong(value == null ? listListEntry.cellDefaultValue : value);
+        }
+
+        @Override
+        public Long getValue() {
+            return value.get();
+        }
+
+        @Override
+        protected double getValueForSlider() {
+            return ((double) this.value.get() - listListEntry.minimum) / Math.abs(listListEntry.maximum - listListEntry.minimum);
+        }
+
+        @Override
+        protected void setValueFromSlider(double value) {
+            this.value.set((long) (listListEntry.minimum + Math.abs(listListEntry.maximum - listListEntry.minimum) * value));
+        }
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/ManagedSliderWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/ManagedSliderWidget.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.gui.widget;
 
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/ManagedSliderWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/ManagedSliderWidget.java
@@ -1,0 +1,98 @@
+package me.shedaniel.clothconfig2.gui.widget;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.chat.NarratorChatListener;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * A slider widget whose state is partially managed by a parent {@link Context}
+ * object.
+ */
+public class ManagedSliderWidget extends AbstractSliderButton {
+    private static final ResourceLocation WIDGETS_TEX = new ResourceLocation("textures/gui/widgets.png");
+
+    private final Context context;
+
+    public ManagedSliderWidget(int x, int y, int width, int height, Context context) {
+        super(x, y, width, height, NarratorChatListener.NO_TITLE, 0);
+
+        this.context = context;
+    }
+
+    public void syncValueFromContext() {
+        this.value = context.value();
+        updateMessage();
+    }
+
+    @Override
+    public void updateMessage() {
+        setMessage(context.message());
+    }
+
+    @Override
+    protected void applyValue() {
+        context.valueApplied(value);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int int_2, int int_3) {
+        if (!context.editable())
+            return false;
+        return super.keyPressed(keyCode, int_2, int_3);
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int mouseButton, double deltaX, double deltaY) {
+        if (!context.editable())
+            return false;
+        return super.mouseDragged(mouseX, mouseY, mouseButton, deltaX, deltaY);
+    }
+
+    @Override
+    protected final void renderBg(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
+        /*
+         * If the width is greater than 200, then fill in the gap in the middle with more button bg
+         */
+        int gap = width - 200;
+        if (gap > 0) {
+            client.getTextureManager().bind(WIDGETS_TEX);
+
+            int offset = 100;
+            do {
+                blit(matrices, x + offset, y, 1, 46 + 0 * 20, Math.min(gap, 198), height);
+
+                offset += 198;
+                gap -= 198;
+            } while (gap > 0);
+        }
+
+        // Render anything on top of the background but below the scrubber
+        renderBgHighlight(matrices, client, mouseX, mouseY);
+
+        // Render the scrubber on top of anything we've drawn
+        renderScrubber(matrices, client, mouseX, mouseY);
+    }
+
+    protected void renderBgHighlight(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
+    }
+
+    protected void renderScrubber(PoseStack matrices, Minecraft client, int mouseX, int mouseY) {
+        super.renderBg(matrices, client, mouseX, mouseY);
+    }
+
+    /**
+     * Provides a set of operations to allow a parent object to manage a {@link ManagedSliderWidget}.
+     */
+    public interface Context {
+        Component message();
+
+        double value();
+
+        void valueApplied(double value);
+
+        boolean editable();
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
@@ -164,10 +164,20 @@ public class ConfigEntryBuilderImpl implements ConfigEntryBuilder {
     }
     
     @Override
+    public IntSliderListBuilder startIntSliderList(Component fieldNameKey, List<Integer> value, int min, int max) {
+        return new IntSliderListBuilder(resetButtonKey, fieldNameKey, value, min, max);
+    }
+
+    @Override
     public LongSliderBuilder startLongSlider(Component fieldNameKey, long value, long min, long max) {
         return new LongSliderBuilder(resetButtonKey, fieldNameKey, value, min, max);
     }
     
+    @Override
+    public LongSliderListBuilder startLongSliderList(Component fieldNameKey, List<Long> value, long min, long max) {
+        return new LongSliderListBuilder(resetButtonKey, fieldNameKey, value, min, max);
+    }
+
     @Override
     public KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value) {
         return new KeyCodeBuilder(resetButtonKey, fieldNameKey, value);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/AbstractSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/AbstractSliderListBuilder.java
@@ -1,0 +1,154 @@
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.AbstractSliderListEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public abstract class AbstractSliderListBuilder<T, C extends AbstractSliderListEntry.AbstractSliderListCell<T, C, E>, E extends AbstractSliderListEntry<T, C, E>, SELF extends AbstractSliderListBuilder<T, C, E, SELF>> extends FieldBuilder<List<T>, E> {
+    private final List<T> value;
+    private T cellDefaultValue = null;
+    private T max;
+    private T min;
+    private boolean expanded = false;
+    private Function<T, Component> textGetter = null;
+    private Consumer<List<T>> saveConsumer = null;
+    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private Function<E, C> createNewInstance;
+    private Function<T, Optional<Component>> cellErrorSupplier;
+    private Function<List<T>, Optional<Component[]>> tooltipSupplier = list -> Optional.empty();
+    private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
+
+    public AbstractSliderListBuilder(Component resetButtonKey, Component fieldNameKey, List<T> value, T min, T max) {
+        super(resetButtonKey, fieldNameKey);
+        this.value = value;
+        this.min = min;
+        this.max = max;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setDefaultValue(Supplier<List<T>> defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setDefaultValue(List<T> defaultValue) {
+        this.defaultValue = () -> defaultValue;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setCellDefaultValue(T cellDefaultValue) {
+        this.cellDefaultValue = cellDefaultValue;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> removeCellDefaultValue() {
+        this.cellDefaultValue = null;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setMax(T max) {
+        this.max = max;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setMin(T min) {
+        this.min = min;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setExpanded(boolean expanded) {
+        this.expanded = expanded;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setTextGetter(Function<T, Component> textGetter) {
+        this.textGetter = textGetter;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setSaveConsumer(Consumer<List<T>> saveConsumer) {
+        this.saveConsumer = saveConsumer;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setDeleteButtonEnabled(boolean deleteButtonEnabled) {
+        this.deleteButtonEnabled = deleteButtonEnabled;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setInsertInFront(boolean insertInFront) {
+        this.insertInFront = insertInFront;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setCreateNewInstance(Function<E, C> createNewInstance) {
+        this.createNewInstance = createNewInstance;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setCellErrorSupplier(Function<T, Optional<Component>> cellErrorSupplier) {
+        this.cellErrorSupplier = cellErrorSupplier;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setErrorSupplier(Function<List<T>, Optional<Component>> errorSupplier) {
+        this.errorSupplier = errorSupplier;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setTooltipSupplier(Supplier<Optional<Component[]>> tooltipSupplier) {
+        this.tooltipSupplier = list -> tooltipSupplier.get();
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setTooltipSupplier(Function<List<T>, Optional<Component[]>> tooltipSupplier) {
+        this.tooltipSupplier = tooltipSupplier;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setTooltip(Optional<Component[]> tooltip) {
+        this.tooltipSupplier = list -> tooltip;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setTooltip(Component... tooltip) {
+        this.tooltipSupplier = list -> Optional.ofNullable(tooltip);
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setAddButtonTooltip(Component addTooltip) {
+        this.addTooltip = addTooltip;
+        return this;
+    }
+
+    public AbstractSliderListBuilder<T, C, E, SELF> setRemoveButtonTooltip(Component removeTooltip) {
+        this.removeTooltip = removeTooltip;
+        return this;
+    }
+
+    protected abstract E buildEntry(Component fieldNameKey, T min, T max, List<T> value, boolean expanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<T>> saveConsumer, Supplier<List<T>> defaultValue, T cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront);
+
+    @Override
+    public E build() {
+        E entry = buildEntry(getFieldNameKey(), min, max, value, expanded, null, saveConsumer, defaultValue, cellDefaultValue == null ? min : cellDefaultValue, getResetButtonKey(), isRequireRestart(), deleteButtonEnabled, insertInFront);
+        if (textGetter != null)
+            entry.setTextGetter(textGetter);
+        if (createNewInstance != null)
+            entry.setCreateNewInstance(createNewInstance);
+        entry.setCellErrorSupplier(cellErrorSupplier);
+        entry.setTooltipSupplier(() -> tooltipSupplier.apply(entry.getValue()));
+        entry.setAddTooltip(addTooltip);
+        entry.setRemoveTooltip(removeTooltip);
+        if (errorSupplier != null)
+            entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
+        return entry;
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/AbstractSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/AbstractSliderListBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.AbstractSliderListEntry;

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderListBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.IntegerSliderListEntry;

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderListBuilder.java
@@ -1,0 +1,23 @@
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.IntegerSliderListEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class IntSliderListBuilder extends AbstractSliderListBuilder<Integer, IntegerSliderListEntry.IntegerSliderListCell, IntegerSliderListEntry, IntSliderListBuilder> {
+    public IntSliderListBuilder(Component resetButtonKey, Component fieldNameKey, List<Integer> value, int min, int max) {
+        super(resetButtonKey, fieldNameKey, value, min, max);
+    }
+
+    @Override
+    protected IntegerSliderListEntry buildEntry(Component fieldNameKey, Integer min, Integer max, List<Integer> value, boolean expanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<Integer>> saveConsumer, Supplier<List<Integer>> defaultValue, Integer cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        return new IntegerSliderListEntry(fieldNameKey, min, max, value, expanded, tooltipSupplier, saveConsumer, defaultValue, cellDefaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderListBuilder.java
@@ -1,0 +1,23 @@
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.LongSliderListEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class LongSliderListBuilder extends AbstractSliderListBuilder<Long, LongSliderListEntry.LongSliderListCell, LongSliderListEntry, LongSliderListBuilder> {
+    public LongSliderListBuilder(Component resetButtonKey, Component fieldNameKey, List<Long> value, long min, long max) {
+        super(resetButtonKey, fieldNameKey, value, min, max);
+    }
+
+    @Override
+    protected LongSliderListEntry buildEntry(Component fieldNameKey, Long min, Long max, List<Long> value, boolean expanded, Supplier<Optional<Component[]>> tooltipSupplier, Consumer<List<Long>> saveConsumer, Supplier<List<Long>> defaultValue, Long cellDefaultValue, Component resetButtonKey, boolean requiresRestart, boolean deleteButtonEnabled, boolean insertInFront) {
+        return new LongSliderListEntry(fieldNameKey, min, max, value, expanded, tooltipSupplier, saveConsumer, defaultValue, cellDefaultValue, resetButtonKey, requiresRestart, deleteButtonEnabled, insertInFront);
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderListBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.gui.entries.LongSliderListEntry;


### PR DESCRIPTION
The corresponding entry objects will be configured by AutoConfig when `@ConfigEntry.Gui.BoundedDiscrete` is present for fields of the following types:

* `IntegerSliderListEntry`: `List<Integer>`, `Integer[]`, `int[]`
* `LongSliderListEntry`: `List<Long>`, `Long[]`, `long[]`

~I would note that I pretty much just copied and pasted `IntegerSliderListEntry` to create `LongSliderListEntry` and once I was done all the differences between the two entries, their cells, and builders were minimal, so it feels like they could have a more DRY implementation.~ Also, it's seems likely that more of the implementation could be shared between the normal slider entries and the slider list entries, but I didn't try to achieve that ~either~.

One final question I have is regarding copyright notices on files, which I did not add. If you want to let me know what you want to do there, I can amend this PR. I'm assuming you don't have a formal CLA, but I'm happy contributing these changes under the stated LGPL license.

Here's an example of what this slider list looks like in the config screen of my mod:

![Screen Shot 2021-03-04 at 11 29 37 PM](https://user-images.githubusercontent.com/76367/110082145-cff1ab00-7d41-11eb-9014-b9ecce0851fd.png)
