### PR TITLE
Allow gradlew javadoc to run successfully

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,23 @@ allprojects {
 
         ignoreFailures = true
     }
+
+    javadoc {
+        options.source = 8
+
+        options.tags = [
+            "apiNote:a:API Note:",
+            "implSpec:a:Implementation Requirements:",
+            "implNote:a:Implementation Note:"
+        ]
+
+        options.links = [
+            'https://docs.oracle.com/javase/8/docs/api/'
+        ]
+
+        options.group('AutoConfig', ['me.shedaniel.autoconfig', 'me.shedaniel.autoconfig.*'])
+        options.group('Cloth Config', ['me.shedaniel.clothconfig2', 'me.shedaniel.clothconfig2.*'])
+    }
 }
 
 task licenseFormatAll

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractListListEntry.java
@@ -90,9 +90,9 @@ public abstract class AbstractListListEntry<T, C extends AbstractListListEntry.A
     }
     
     /**
-     * @param <T>           the configuration object type
-     * @param <SELF>        the "curiously recurring template pattern" type parameter for this class
-     * @param <OUTER_SELF>> the "curiously recurring template pattern" type parameter for the outer class
+     * @param <T>          the configuration object type
+     * @param <SELF>       the "curiously recurring template pattern" type parameter for this class
+     * @param <OUTER_SELF> the "curiously recurring template pattern" type parameter for the outer class
      * @see AbstractListListEntry
      */
     @ApiStatus.Internal

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -56,9 +56,9 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
     }
     
     /**
-     * @param <T>           the configuration object type
-     * @param <SELF>        the "curiously recurring template pattern" type parameter for this class
-     * @param <OUTER_SELF>> the "curiously recurring template pattern" type parameter for the outer class
+     * @param <T>          the configuration object type
+     * @param <SELF>       the "curiously recurring template pattern" type parameter for this class
+     * @param <OUTER_SELF> the "curiously recurring template pattern" type parameter for the outer class
      * @see AbstractTextFieldListListEntry
      */
     @ApiStatus.Internal

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * @param <T>    the configuration object type
  * @param <C>    the cell type
  * @param <SELF> the "curiously recurring template pattern" type parameter
- * @implNote See <a href="https://stackoverflow.com/questions/7354740/is-there-a-way-to-refer-to-the-current-type-with-a-type-variable">Is there a way to refer to the current type with a type variable?</href> on Stack Overflow.
+ * @implNote See <a href="https://stackoverflow.com/questions/7354740/is-there-a-way-to-refer-to-the-current-type-with-a-type-variable">Is there a way to refer to the current type with a type variable?</a> on Stack Overflow.
  */
 @Environment(EnvType.CLIENT)
 public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends BaseListEntry<T, C, SELF>> extends TooltipListEntry<List<T>> implements Expandable {


### PR DESCRIPTION
* Add tags configuration to include @implNote
* Add JavaDoc groups to separate AutoConfig and Cloth Config
* Link to Java 8 docs
* Fix a few javadoc formatting issues