### PR TITLE
Remove deprecated ModMenu API

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,8 +25,5 @@
     "depends": {
         "fabricloader": ">=0.9.0"
     },
-    "accessWidener": "cloth-config.accessWidener",
-    "custom": {
-        "modmenu:api": true
-    }
+    "accessWidener": "cloth-config.accessWidener"
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,5 +25,10 @@
     "depends": {
         "fabricloader": ">=0.9.0"
     },
-    "accessWidener": "cloth-config.accessWidener"
+    "accessWidener": "cloth-config.accessWidener",
+    "custom": {
+        "modmenu": {
+            "badges": [ "library" ]
+        }
+    }
 }


### PR DESCRIPTION
- Removes log warn
- Supports new API
- Properly fixes #93 