### PR TITLE
Allow for the Bounding Doubles and Floats Fields within Auto Config

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -61,18 +61,30 @@ public class ConfigEntry {
     public @interface ColorPicker {
         boolean allowAlpha() default false;
     }
-
-//    /**
-//     * Applies to float and double fields.
-//     * In a future version it will enforce bounds at deserialization.
-//     */
-//    @Retention(RetentionPolicy.RUNTIME)
-//    @Target(ElementType.FIELD)
-//    public @interface BoundedFloating {
-//        double min() default 0;
-//
-//        double max();
-//    }
+    
+    /**
+     * Applies to double fields.
+     * In a future version it will enforce bounds at deserialization.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface BoundedDouble {
+        double min() default 0;
+        
+        double max();
+    }
+    
+    /**
+     * Applies to float fields.
+     * In a future version it will enforce bounds at deserialization.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface BoundedFloat {
+        float min() default 0;
+        
+        float max();
+    }
     
     public static class Gui {
         private Gui() {

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -106,6 +106,52 @@ public class DefaultGuiProviders {
                 ConfigEntry.BoundedDiscrete.class
         );
         
+        //Bounded float/Double Fields
+        registry.registerAnnotationProvider(
+                (i13n, field, config, defaults, guiProvider) -> {
+                    ConfigEntry.BoundedFloat bounds
+                            = field.getAnnotation(ConfigEntry.BoundedFloat.class);
+                
+                    return Collections.singletonList(
+                            ENTRY_BUILDER.startFloatField(
+                                            new TranslatableComponent(i13n),
+                                            getUnsafely(field, config, 0f)
+                                            
+                                    )
+                                    .setMax(bounds.max())
+                                    .setMin(bounds.min())
+                                    .setDefaultValue(() -> getUnsafely(field, defaults))
+                                    .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                                    .build()
+                    );
+                },
+                field -> field.getType() == float.class || field.getType() == Float.class,
+                ConfigEntry.BoundedFloat.class
+        );
+    
+        registry.registerAnnotationProvider(
+                (i13n, field, config, defaults, guiProvider) -> {
+                    ConfigEntry.BoundedDouble bounds
+                            = field.getAnnotation(ConfigEntry.BoundedDouble.class);
+                
+                    return Collections.singletonList(
+                            ENTRY_BUILDER.startDoubleField(
+                                            new TranslatableComponent(i13n),
+                                            getUnsafely(field, config, 0f)
+                                
+                                    )
+                                    .setMax(bounds.max())
+                                    .setMin(bounds.min())
+                                    .setDefaultValue(() -> getUnsafely(field, defaults))
+                                    .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                                    .build()
+                    );
+                },
+                field -> field.getType() == double.class || field.getType() == Double.class,
+                ConfigEntry.BoundedDouble.class
+        );
+        //End of Bounded float/Double Fields
+        
         registry.registerAnnotationProvider(
                 (i13n, field, config, defaults, guiProvider) -> {
                     ConfigEntry.ColorPicker colorPicker


### PR DESCRIPTION
This PR adds the ability to give bounds to fields like Double's and Float's, Theoretically this could be expand to possible encompass all types of value fields to also include Long's and Int's. 