### PR TITLE
New elements should be added to the end of a list by default

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -253,7 +253,7 @@ public class DefaultGuiProviders {
                             () -> getUnsafely(field, defaults),
                             ENTRY_BUILDER.getResetButtonKey(),
                             true,
-                            true,
+                            false,
                             (elem, nestedListListEntry) -> {
                                 if (elem == null) {
                                     Object newDefaultElemValue = Utils.constructUnsafely(fieldTypeParam);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
@@ -44,7 +44,7 @@ public class DoubleListBuilder extends FieldBuilder<List<Double>, DoubleListList
     private Double min = null, max = null;
     private Function<DoubleListListEntry, DoubleListListEntry.DoubleListCell> createNewInstance;
     private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
-    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private boolean deleteButtonEnabled = true, insertInFront = false;
     
     public DoubleListBuilder(Component resetButtonKey, Component fieldNameKey, List<Double> value) {
         super(resetButtonKey, fieldNameKey);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
@@ -44,7 +44,7 @@ public class FloatListBuilder extends FieldBuilder<List<Float>, FloatListListEnt
     private Float min = null, max = null;
     private Function<FloatListListEntry, FloatListListEntry.FloatListCell> createNewInstance;
     private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
-    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private boolean deleteButtonEnabled = true, insertInFront = false;
     
     public FloatListBuilder(Component resetButtonKey, Component fieldNameKey, List<Float> value) {
         super(resetButtonKey, fieldNameKey);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
@@ -44,7 +44,7 @@ public class IntListBuilder extends FieldBuilder<List<Integer>, IntegerListListE
     private Integer min = null, max = null;
     private Function<IntegerListListEntry, IntegerListListEntry.IntegerListCell> createNewInstance;
     private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
-    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private boolean deleteButtonEnabled = true, insertInFront = false;
     
     public IntListBuilder(Component resetButtonKey, Component fieldNameKey, List<Integer> value) {
         super(resetButtonKey, fieldNameKey);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
@@ -44,7 +44,7 @@ public class LongListBuilder extends FieldBuilder<List<Long>, LongListListEntry>
     private Long min = null, max = null;
     private Function<LongListListEntry, LongListListEntry.LongListCell> createNewInstance;
     private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
-    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private boolean deleteButtonEnabled = true, insertInFront = false;
     
     public LongListBuilder(Component resetButtonKey, Component fieldNameKey, List<Long> value) {
         super(resetButtonKey, fieldNameKey);

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
@@ -43,7 +43,7 @@ public class StringListBuilder extends FieldBuilder<List<String>, StringListList
     private boolean expanded = false;
     private Function<StringListListEntry, StringListListEntry.StringListCell> createNewInstance;
     private Component addTooltip = new TranslatableComponent("text.cloth-config.list.add"), removeTooltip = new TranslatableComponent("text.cloth-config.list.remove");
-    private boolean deleteButtonEnabled = true, insertInFront = true;
+    private boolean deleteButtonEnabled = true, insertInFront = false;
     
     public StringListBuilder(Component resetButtonKey, Component fieldNameKey, List<String> value) {
         super(resetButtonKey, fieldNameKey);


### PR DESCRIPTION
While it's subjectively more natural for most people to see the last added item at the end of the list, there's an objective point in defense of this change - sometimes lists in configs represent some ordered data (e.g., priority list), therefore it's critical for users to be able to add new items without disrupting the entire order with all entries being shifted.

A default option should be practical for most users, so it’s better to replace the current behavior with a more obvious one.

Fixes #71, closes shedaniel/AutoConfig#37