### PR TITLE
Ensure tooltips stay on screen & doesn't get in the way

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
@@ -56,14 +56,20 @@ public abstract class TooltipListEntry<T> extends AbstractConfigListEntry<T> {
     public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
         super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
         if (isMouseInside(mouseX, mouseY, x, y, entryWidth, entryHeight)) {
-            Optional<Component[]> tooltip = getTooltip(mouseX, mouseY);
-            if (tooltip.isPresent() && tooltip.get().length > 0)
-                addTooltip(Tooltip.of(new Point(mouseX, mouseY), postProcessTooltip(tooltip.get())));
+            getTooltip(mouseX, mouseY).ifPresent(tooltip -> {
+                if (tooltip.length > 0) {
+                    FormattedCharSequence[] processedTooltip = postProcessTooltip(tooltip);
+                    int height = processedTooltip.length * Minecraft.getInstance().font.lineHeight;
+                    addTooltip(Tooltip.of(new Point(mouseX, mouseY - height), processedTooltip));
+                }
+            });
         }
     }
     
     private FormattedCharSequence[] postProcessTooltip(Component[] tooltip) {
-        return Arrays.stream(tooltip).flatMap(component -> Minecraft.getInstance().font.split(component, getConfigScreen().width).stream())
+        int maxWidth = getConfigScreen().width / 2 - 4;
+        return Arrays.stream(tooltip)
+                .flatMap(component -> Minecraft.getInstance().font.split(component, maxWidth).stream())
                 .toArray(FormattedCharSequence[]::new);
     }
     


### PR DESCRIPTION
When the tooltip is wider than half the screen width, it often ends up partially off-screen.

This PR fixes that by ensuring the tooltip always wraps to less than `screen.width / 2`.

Additionally, it shifts the tooltip above the cursor, instead of in-line with it. This allows the user to more easily read what they're hovering over without the tooltip getting in the way. Especially multi-line tooltips.

FYI the upcoming 1.19.4 release _"Changed how tooltips in the menu UI are positioned so buttons are still readable"_ in [Snapshot 23w05a](https://www.minecraft.net/en-us/article/minecraft-snapshot-23w05a), so the `mouseY - height` tooltip shift may be redundant or duplicated once that's released.