### PR TITLE
Fix crash caused by pressing TAB

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
@@ -132,11 +132,11 @@ public class SearchFieldEntry extends AbstractConfigListEntry<Object> {
     
     @Override
     public List<? extends NarratableEntry> narratables() {
-        return List.of(editBox);
+        return Collections.singletonList(editBox);
     }
     
     @Override
     public List<? extends GuiEventListener> children() {
-        return List.of(editBox);
+        return Collections.singletonList(editBox);
     }
 }


### PR DESCRIPTION
Fixes #176, which was caused by `SearchFieldEntry.children()` using `List.of()` to form the list of children.

`List.of()` returns an unmodifiable list, which doesn't permit `null` members. This means that [`List.indexOf()` will throw a `NullPointerException`](https://docs.oracle.com/javase/8/docs/api/java/util/List.html#indexOf-java.lang.Object-) when `null` is passes to it, reveals a bug in the vanilla method `ContainerEventHandler#changeFocus(boolean)`.

<details>
<summary><code>ContainerEventHandler.changeFocus()</code> with comments regarding the vanilla bug</summary>

```java
// decompiled using loom & fernflower, manually cleaned & commented
boolean changeFocusFernFlower(boolean moveForward) {
    GuiEventListener currentlyFocused = this.getFocused();
    boolean focusedIsNotNull = currentlyFocused != null;
    
    // First try letting the currently focused gui handle changing focus
    if (focusedIsNotNull && currentlyFocused.changeFocus(moveForward)) {
        return true;
    }
    
    // Otherwise iterate over the children
    List<? extends GuiEventListener> list = this.children();
    
    // We want to start iterating from the next/previous gui to `currentlyFocused`
    // This is where the crash occurs - if `currentlyFocused` is null & `list` does not allow null entries:
    int index = list.indexOf(currentlyFocused); // NullPointerException
    int start;
    // This is a vanilla bug:
    // list.indexOf() should only be run if focusedIsNotNull
    if (focusedIsNotNull && index >= 0) {
        start = index + (moveForward ? 1 : 0);
    } else {
        start = moveForward ? 0 : list.size();
    }
    /* Vanilla fix:
    // Mojang could fix this by only calling indexOf() when `focusedIsNotNull`:
    int index, start;
    if (focusedIsNotNull && (index = list.indexOf(guiEventListener)) >= 0) {
        start = index + (moveForward ? 1 : 0);
    } else {
        start = moveForward ? 0 : list.size();
    }
     */

    // Get an iterator starting at the appropriate index
    ListIterator<? extends GuiEventListener> iterator = list.listIterator(start);

    // Get a reference to either iterator.hasNext() or iterator.hasPrevious()
    BooleanSupplier hasAnother;
    if (moveForward) {
        Objects.requireNonNull(iterator);
        hasAnother = iterator::hasNext;
    } else {
        Objects.requireNonNull(iterator);
        hasAnother = iterator::hasPrevious;
    }

    // Get a reference to either iterator.next() or iterator.previous()
    Supplier<? extends GuiEventListener> another;
    if (moveForward) {
        Objects.requireNonNull(iterator);
        another = iterator::next;
    } else {
        Objects.requireNonNull(iterator);
        another = iterator::previous;
    }

    // Iterate until a gui accepts focus, or we run out of guis
    GuiEventListener gui;
    do {
        if (!hasAnother.getAsBoolean()) {
            this.setFocused(null);
            return false;
        }
        
        gui = another.get();
    } while(!gui.changeFocus(moveForward));

    this.setFocused(gui);
    return true;
}
```

</details>

This PR fixes the issue by having `SearchFieldEntry.children()` use `Collections.singletonList()` instead of `List.of()`. Singleton lists permit `null` values, so `indexOf()` doesn't need to throw any exceptions when we ask for the index of `null`.

I've also included a couple commits fixing mapping names I stumbled across while debugging. I can open a separate PR for those if you like, but I figured so long as the commits don't get squashed together when merging one small PR should be ok. _EDIT: moved to #202_