### PR TITLE
cloth-config dependency support

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/api/AbstractConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/AbstractConfigEntry.java
@@ -29,21 +29,21 @@ import me.shedaniel.clothconfig2.gui.widget.DynamicElementListWidget;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.util.FormattedCharSequence;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
-public abstract class AbstractConfigEntry<T> extends DynamicElementListWidget.ElementEntry<AbstractConfigEntry<T>> implements ReferenceProvider<T> {
+public abstract class AbstractConfigEntry<T> extends DynamicElementListWidget.ElementEntry<AbstractConfigEntry<T>> implements ReferenceProvider<T>, ValueHolder<T> {
     private AbstractConfigScreen screen;
     private Supplier<Optional<Component>> errorSupplier;
     @Nullable
@@ -92,6 +92,8 @@ public abstract class AbstractConfigEntry<T> extends DynamicElementListWidget.El
             text = text.withStyle(ChatFormatting.ITALIC);
         if (!hasError && !isEdited)
             text = text.withStyle(ChatFormatting.GRAY);
+        if (!isEnabled())
+            text = text.withStyle(ChatFormatting.DARK_GRAY);
         return text;
     }
     
@@ -116,8 +118,6 @@ public abstract class AbstractConfigEntry<T> extends DynamicElementListWidget.El
             this.additionalSearchTags = Iterables.concat(this.additionalSearchTags, tags);
         }
     }
-    
-    public abstract T getValue();
     
     public final Optional<Component> getConfigError() {
         if (errorSupplier != null && errorSupplier.get().isPresent())
@@ -144,6 +144,19 @@ public abstract class AbstractConfigEntry<T> extends DynamicElementListWidget.El
     
     public final void addTooltip(@NotNull Tooltip tooltip) {
         screen.addTooltip(tooltip);
+    }
+    
+    protected FormattedCharSequence[] wrapLinesToScreen(Component[] lines) {
+        return wrapLines(lines, screen.width);
+    }
+    
+    protected FormattedCharSequence[] wrapLines(Component[] lines, int width) {
+        final Font font = Minecraft.getInstance().font;
+        
+        return Arrays.stream(lines)
+                .map(line -> font.split(line, width))
+                .flatMap(List::stream)
+                .toArray(FormattedCharSequence[]::new);
     }
     
     public void updateSelected(boolean isSelected) {}

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/AbstractConfigListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/AbstractConfigListEntry.java
@@ -48,7 +48,7 @@ public abstract class AbstractConfigListEntry<T> extends AbstractConfigEntry<T> 
     }
     
     public boolean isEditable() {
-        return getConfigScreen().isEditable() && editable;
+        return getConfigScreen().isEditable() && editable && isEnabled();
     }
     
     public void setEditable(boolean editable) {

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/DisableableWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/DisableableWidget.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.api;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/DisableableWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/DisableableWidget.java
@@ -1,0 +1,27 @@
+package me.shedaniel.clothconfig2.api;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Experimental
+public interface DisableableWidget {
+    
+    /**
+     * Checks whether this config entry gui is enabled.
+     * 
+     * <p>Requirements are checked independently (once per tick). This method simply reads the result of the latest
+     * check, making it extremely cheap to run.
+     * 
+     * <p>If {@link HideableWidget#isDisplayed()} is false, this will also be false.
+     * 
+     * @return whether the config entry is enabled
+     * @see HideableWidget#isDisplayed()
+     * @see TickableWidget#tick()
+     */
+    boolean isEnabled();
+    
+    void setRequirement(@Nullable Requirement requirement);
+    
+    @Nullable Requirement getRequirement();
+    
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/HideableWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/HideableWidget.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.api;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/HideableWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/HideableWidget.java
@@ -1,0 +1,24 @@
+package me.shedaniel.clothconfig2.api;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Experimental
+public interface HideableWidget {
+    
+    /**
+     * Checks whether this config entry gui is shown on screen.
+     * 
+     * <p>Requirements are checked independently (once per tick). This method simply reads the result of the latest
+     * check, making it extremely cheap to run.
+     * 
+     * @return whether to display the config entry
+     * @see DisableableWidget#isEnabled()
+     * @see TickableWidget#tick()
+     */
+    boolean isDisplayed();
+    
+    void setDisplayRequirement(@Nullable Requirement requirement);
+    
+    @Nullable Requirement getDisplayRequirement();
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/Requirement.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/Requirement.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.api;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/Requirement.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/Requirement.java
@@ -1,0 +1,105 @@
+package me.shedaniel.clothconfig2.api;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Represents a predicate (boolean-valued function) without arguments.
+ *
+ * <p>This is a <a href="{@docRoot}/java/util/function/package-summary.html">functional interface</a>
+ * whose functional method is {@link #check()}.
+ */
+@FunctionalInterface
+@ApiStatus.Experimental
+public interface Requirement {
+    
+    /**
+     * Checks if this requirement is currently true.
+     */
+    boolean check();
+    
+    /**
+     * Generates a {@link Requirement} that is true when {@code dependency}'s value is one of the provided values.
+     */
+    @SafeVarargs
+    static <T> Requirement isValue(ValueHolder<T> dependency, @Nullable T firstValue, @Nullable T... otherValues) {
+        Set<@Nullable T> values = Stream.concat(Stream.of(firstValue), Arrays.stream(otherValues))
+                .collect(Collectors.toCollection(HashSet::new));
+        
+        return () -> values.contains(dependency.getValue());
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when {@code firstDependency}'s value equals {@code secondDependency}'s value.
+     */
+    static <T> Requirement matches(ValueHolder<T> firstDependency, ValueHolder<T> secondDependency) {
+        return () -> Objects.equals(firstDependency.getValue(), secondDependency.getValue());
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when {@code dependency}'s value is true.
+     */
+    static Requirement isTrue(ValueHolder<Boolean> dependency) {
+        return () -> Boolean.TRUE.equals(dependency.getValue());
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when {@code dependency}'s value is false.
+     */
+    static Requirement isFalse(ValueHolder<Boolean> dependency) {
+        return () -> Boolean.FALSE.equals(dependency.getValue());
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when the given {@code requirement} is false.
+     */
+    static Requirement not(Requirement requirement) {
+        return () -> !requirement.check();
+    }
+  
+    /**
+     * Generates a {@link Requirement} that is true when all the given requirements are true.
+     */
+    static Requirement all(Requirement... requirements) {
+        return () -> Arrays.stream(requirements).allMatch(Requirement::check);
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when any of the given requirements are true.
+     */
+    static Requirement any(Requirement... requirements) {
+        return () -> Arrays.stream(requirements).anyMatch(Requirement::check);
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when none of the given requirements are true, i.e. all are false.
+     */
+    static Requirement none(Requirement... requirements) {
+        return () -> Arrays.stream(requirements).noneMatch(Requirement::check);
+    }
+    
+    /**
+     * Generates a {@link Requirement} that is true when precisely one of the given requirements is true.
+     */
+    static Requirement one(Requirement... requirements) {
+        return () -> {
+            // Use a for loop instead of Stream.count() so that we can return early. We only need to count past 1.
+            boolean oneFound = false;
+            for (Requirement requirement : requirements) {
+               if (!requirement.check())
+                   continue;
+               if (oneFound)
+                   return false;
+               oneFound = true;
+            }
+            return oneFound;
+        };
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ValueHolder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ValueHolder.java
@@ -1,0 +1,14 @@
+package me.shedaniel.clothconfig2.api;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface ValueHolder<T> {
+    /**
+     * Get the value held by this Value Holder.
+     * 
+     * <p>Depending on the implementation, this method may or may not be {@link Nullable}.
+     * 
+     * @return the current value.
+     */
+    T getValue();
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ValueHolder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ValueHolder.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package me.shedaniel.clothconfig2.api;
 
 import org.jetbrains.annotations.Nullable;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/ClothConfigScreen.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/ClothConfigScreen.java
@@ -357,7 +357,7 @@ public class ClothConfigScreen extends AbstractTabbedConfigScreen {
         }
         
         @Override
-        protected void renderList(PoseStack matrices, int startX, int startY, int int_3, int int_4, float delta) {
+        protected void renderList(PoseStack matrices, int startX, int startY, int mouseX, int mouseY, float delta) {
             thisTimeTarget = null;
             Rectangle hoverBounds = currentBounds.value();
             if (!hoverBounds.isEmpty()) {
@@ -366,8 +366,8 @@ public class ClothConfigScreen extends AbstractTabbedConfigScreen {
                 alpha = (alpha * 36 / 255) << 24;
                 fillGradient(matrices, hoverBounds.x, hoverBounds.y - scroll, hoverBounds.getMaxX(), hoverBounds.getMaxY() - scroll, 0xFFFFFF | alpha, 0xFFFFFF | alpha);
             }
-            super.renderList(matrices, startX, startY, int_3, int_4, delta);
-            if (thisTimeTarget != null && isMouseOver(int_3, int_4)) {
+            super.renderList(matrices, startX, startY, mouseX, mouseY, delta);
+            if (thisTimeTarget != null && isMouseOver(mouseX, mouseY)) {
                 lastTouch = System.currentTimeMillis();
             }
             if (thisTimeTarget != null && !thisTimeTarget.equals(currentBounds.target())) {

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -110,7 +110,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     
     @Override
     public boolean isExpanded() {
-        return expanded;
+        return expanded && isEnabled();
     }
     
     @Override
@@ -151,11 +151,11 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     public abstract SELF self();
     
     public boolean isDeleteButtonEnabled() {
-        return deleteButtonEnabled;
+        return deleteButtonEnabled && isEnabled();
     }
     
     public boolean isInsertButtonEnabled() {
-        return insertButtonEnabled;
+        return insertButtonEnabled && isEnabled();
     }
 
     public void setDeleteButtonEnabled(boolean deleteButtonEnabled) {
@@ -206,7 +206,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     
     @Override
     public int getItemHeight() {
-        if (expanded) {
+        if (isExpanded()) {
             int i = 24;
             for (BaseListCell entry : cells)
                 i += entry.getCellHeight();
@@ -217,7 +217,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     
     @Override
     public List<? extends GuiEventListener> children() {
-        if (!expanded) {
+        if (!isExpanded()) {
             List<GuiEventListener> elements = new ArrayList<>((List<GuiEventListener>) (List<?>) widgets);
             elements.removeAll(cells);
             return elements;
@@ -273,9 +273,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
             return Optional.of(new Component[]{addTooltip});
         if (removeTooltip != null && isInsideDelete(mouseX, mouseY))
             return Optional.of(new Component[]{removeTooltip});
-        if (getTooltipSupplier() != null)
-            return getTooltipSupplier().get();
-        return Optional.empty();
+        return super.getTooltip(mouseX, mouseY);
     }
     
     @Override
@@ -283,10 +281,11 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
         RenderSystem.setShaderTexture(0, CONFIG_TEX);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        BaseListCell focused = !expanded || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+        BaseListCell focused = !isExpanded() || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+        boolean insideLabel = labelWidget.rectangle.contains(mouseX, mouseY);
         boolean insideCreateNew = isInsideCreateNew(mouseX, mouseY);
         boolean insideDelete = isInsideDelete(mouseX, mouseY);
-        blit(matrices, x - 15, y + 5, 24 + 9, (labelWidget.rectangle.contains(mouseX, mouseY) && !insideCreateNew && !insideDelete ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
+        blit(matrices, x - 15, y + 5, 24 + 9, (isEnabled() ? (insideLabel && !insideCreateNew && !insideDelete ? 18 : 0) : 36) + (isExpanded() ? 9 : 0), 9, 9);
         if (isInsertButtonEnabled())
             blit(matrices, x - 15 + 13, y + 5, 24 + 18, insideCreateNew ? 9 : 0, 9, 9);
         if (isDeleteButtonEnabled())
@@ -295,8 +294,9 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         resetWidget.y = y;
         resetWidget.active = isEditable() && getDefaultValue().isPresent() && !isMatchDefault();
         resetWidget.render(matrices, mouseX, mouseY, delta);
-        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), isDeleteButtonEnabled() ? x + 24 : x + 24 - 9, y + 6, labelWidget.rectangle.contains(mouseX, mouseY) && !resetWidget.isMouseOver(mouseX, mouseY) && !insideDelete && !insideCreateNew ? 0xffe6fe16 : getPreferredTextColor());
-        if (expanded) {
+        int offset = (isInsertButtonEnabled() || isDeleteButtonEnabled() ? 6 : 0) + (isInsertButtonEnabled() ? 9 : 0) + (isDeleteButtonEnabled() ? 9 : 0);
+        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), x + offset, y + 6, insideLabel && !resetWidget.isMouseOver(mouseX, mouseY) && !insideDelete && !insideCreateNew ? 0xffe6fe16 : getPreferredTextColor());
+        if (isExpanded()) {
             int yy = y + 24;
             for (BaseListCell cell : cells) {
                 cell.render(matrices, -1, yy, x + 14, entryWidth - 14, cell.getCellHeight(), mouseX, mouseY, getParent().getFocused() != null && getParent().getFocused().equals(this) && getFocused() != null && getFocused().equals(cell), delta);
@@ -308,7 +308,7 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     @Override
     public void updateSelected(boolean isSelected) {
         for (C cell : cells) {
-            cell.updateSelected(isSelected && getFocused() == cell && expanded);
+            cell.updateSelected(isSelected && getFocused() == cell && isExpanded());
         }
     }
     
@@ -325,11 +325,13 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
         protected Rectangle rectangle = new Rectangle();
         
         @Override
-        public boolean mouseClicked(double double_1, double double_2, int int_1) {
-            if (resetWidget.isMouseOver(double_1, double_2)) {
+        public boolean mouseClicked(double mouseX, double mouseY, int int_1) {
+            if (!isEnabled())
                 return false;
-            } else if (isInsideCreateNew(double_1, double_2)) {
-                expanded = true;
+            if (resetWidget.isMouseOver(mouseX, mouseY)) {
+                return false;
+            } else if (isInsideCreateNew(mouseX, mouseY)) {
+                setExpanded(true);
                 C cell;
                 if (insertInFront()) {
                     cells.add(0, cell = createNewInstance.apply(BaseListEntry.this.self()));
@@ -341,9 +343,9 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
                 cell.onAdd();
                 Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
-            } else if (isDeleteButtonEnabled() && isInsideDelete(double_1, double_2)) {
+            } else if (isDeleteButtonEnabled() && isInsideDelete(mouseX, mouseY)) {
                 GuiEventListener focused = getFocused();
-                if (expanded && focused instanceof BaseListCell) {
+                if (isExpanded() && focused instanceof BaseListCell) {
                     ((BaseListCell) focused).onDelete();
                     //noinspection SuspiciousMethodCalls
                     cells.remove(focused);
@@ -351,8 +353,8 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
                     Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 }
                 return true;
-            } else if (rectangle.contains(double_1, double_2)) {
-                expanded = !expanded;
+            } else if (rectangle.contains(mouseX, mouseY)) {
+                setExpanded(!expanded);
                 Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return true;
             }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
@@ -114,15 +114,16 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     @Override
     public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
         super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
+        boolean insideWidget = widget.rectangle.contains(mouseX, mouseY);
         RenderSystem.setShaderTexture(0, CONFIG_TEX);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        blit(matrices, x - 15, y + 5, 24, (widget.rectangle.contains(mouseX, mouseY) ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
-        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), x, y + 6, widget.rectangle.contains(mouseX, mouseY) ? 0xffe6fe16 : -1);
+        blit(matrices, x - 15, y + 5, 24, (isEnabled() ? (insideWidget ? 18 : 0) : 36) + (isExpanded() ? 9 : 0), 9, 9);
+        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), x, y + 6, insideWidget ? 0xffe6fe16 : -1);
         for (AbstractConfigListEntry entry : entries) {
             entry.setParent(getParent());
             entry.setScreen(getConfigScreen());
         }
-        if (expanded) {
+        if (isExpanded()) {
             int yy = y + 24;
             for (AbstractConfigListEntry<?> entry : entries) {
                 entry.render(matrices, -1, yy, x + 14, entryWidth - 14, entry.getItemHeight(), mouseX, mouseY, isHovered, delta);
@@ -143,7 +144,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     
     @Override
     public int getItemHeight() {
-        if (expanded) {
+        if (isExpanded()) {
             int i = 24;
             for (AbstractConfigListEntry<?> entry : entries)
                 i += entry.getItemHeight();
@@ -155,7 +156,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     @Override
     public void updateSelected(boolean isSelected) {
         for (AbstractConfigListEntry<?> entry : entries) {
-            entry.updateSelected(expanded && isSelected && getFocused() == entry);
+            entry.updateSelected(isExpanded() && isSelected && getFocused() == entry);
         }
     }
     
@@ -166,7 +167,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     
     @Override
     public void lateRender(PoseStack matrices, int mouseX, int mouseY, float delta) {
-        if (expanded) {
+        if (isExpanded()) {
             for (AbstractConfigListEntry<?> entry : entries) {
                 entry.lateRender(matrices, mouseX, mouseY, delta);
             }
@@ -176,7 +177,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     @SuppressWarnings("deprecation")
     @Override
     public int getMorePossibleHeight() {
-        if (!expanded) return -1;
+        if (!isExpanded()) return -1;
         List<Integer> list = new ArrayList<>();
         int i = 24;
         for (AbstractConfigListEntry<?> entry : entries) {
@@ -191,12 +192,12 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     
     @Override
     public List<? extends GuiEventListener> children() {
-        return expanded ? (List) children : Collections.singletonList(widget);
+        return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
     
     @Override
     public List<? extends NarratableEntry> narratables() {
-        return expanded ? (List) children : Collections.singletonList(widget);
+        return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
     
     @Override
@@ -216,7 +217,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     
     @Override
     public boolean isExpanded() {
-        return this.expanded;
+        return this.expanded && isEnabled();
     }
     
     @Override
@@ -229,9 +230,9 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
         private boolean isHovered;
         
         @Override
-        public boolean mouseClicked(double double_1, double double_2, int int_1) {
-            if (rectangle.contains(double_1, double_2)) {
-                expanded = !expanded;
+        public boolean mouseClicked(double mouseX, double mouseY, int int_1) {
+            if (isEnabled() && rectangle.contains(mouseX, mouseY)) {
+                setExpanded(!expanded);
                 Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return isHovered = true;
             }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
@@ -69,7 +69,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     
     @Override
     public boolean isExpanded() {
-        return expanded;
+        return expanded && isEnabled();
     }
     
     @Override
@@ -104,7 +104,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
             @Override
             public Iterator<AbstractConfigListEntry> iterator() {
                 return Iterators.filter(entries.iterator(), entry -> {
-                    return getConfigScreen() != null && getConfigScreen().matchesSearch(entry.getSearchTags());
+                    return entry.isDisplayed() && getConfigScreen() != null && getConfigScreen().matchesSearch(entry.getSearchTags());
                 });
             }
             
@@ -130,13 +130,14 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
         super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
         RenderSystem.setShaderTexture(0, CONFIG_TEX);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        blit(matrices, x - 15, y + 5, 24, (widget.rectangle.contains(mouseX, mouseY) ? 18 : 0) + (expanded ? 9 : 0), 9, 9);
-        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), x, y + 6, widget.rectangle.contains(mouseX, mouseY) ? 0xffe6fe16 : -1);
+        boolean insideWidget = widget.rectangle.contains(mouseX, mouseY);
+        blit(matrices, x - 15, y + 5, 24, (isEnabled() ? (insideWidget ? 18 : 0) : 36) + (isExpanded() ? 9 : 0), 9, 9);
+        Minecraft.getInstance().font.drawShadow(matrices, getDisplayedFieldName().getVisualOrderText(), x, y + 6, insideWidget ? 0xffe6fe16 : 0xffffffff);
         for (AbstractConfigListEntry<?> entry : entries) {
             entry.setParent((DynamicEntryListWidget) getParent());
             entry.setScreen(getConfigScreen());
         }
-        if (expanded) {
+        if (isExpanded()) {
             int yy = y + 24;
             for (AbstractConfigListEntry<?> entry : filteredEntries()) {
                 entry.render(matrices, -1, yy, x + 14, entryWidth - 14, entry.getItemHeight(), mouseX, mouseY, isHovered && getFocused() == entry, delta);
@@ -146,9 +147,17 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     }
     
     @Override
+    public void tick() {
+        super.tick();
+        for (AbstractConfigListEntry<?> entry : entries) {
+           entry.tick(); 
+        }
+    }
+    
+    @Override
     public void updateSelected(boolean isSelected) {
         for (AbstractConfigListEntry<?> entry : entries) {
-            entry.updateSelected(expanded && isSelected && getFocused() == entry && getConfigScreen().matchesSearch(entry.getSearchTags()));
+            entry.updateSelected(isExpanded() && isSelected && getFocused() == entry && entry.isDisplayed() && getConfigScreen().matchesSearch(entry.getSearchTags()));
         }
     }
     
@@ -164,7 +173,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     
     @Override
     public void lateRender(PoseStack matrices, int mouseX, int mouseY, float delta) {
-        if (expanded) {
+        if (isExpanded()) {
             for (AbstractConfigListEntry<?> entry : filteredEntries()) {
                 entry.lateRender(matrices, mouseX, mouseY, delta);
             }
@@ -174,7 +183,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     @SuppressWarnings("deprecation")
     @Override
     public int getMorePossibleHeight() {
-        if (!expanded) return -1;
+        if (!isExpanded()) return -1;
         List<Integer> list = new ArrayList<>();
         int i = 24;
         for (AbstractConfigListEntry<?> entry : filteredEntries()) {
@@ -198,7 +207,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     
     @Override
     public int getItemHeight() {
-        if (expanded) {
+        if (isExpanded()) {
             int i = 24;
             for (AbstractConfigListEntry<?> entry : filteredEntries())
                 i += entry.getItemHeight();
@@ -214,12 +223,12 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     
     @Override
     public List<? extends GuiEventListener> children() {
-        return expanded ? (List) children : Collections.singletonList(widget);
+        return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
     
     @Override
     public List<? extends NarratableEntry> narratables() {
-        return expanded ? (List) children : Collections.singletonList(widget);
+        return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
     
     @Override
@@ -246,9 +255,9 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
         private boolean isHovered;
         
         @Override
-        public boolean mouseClicked(double double_1, double double_2, int int_1) {
-            if (rectangle.contains(double_1, double_2)) {
-                expanded = !expanded;
+        public boolean mouseClicked(double mouseX, double mouseY, int int_1) {
+            if (isEnabled() && rectangle.contains(mouseX, mouseY)) {
+                setExpanded(!expanded);
                 Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
                 return isHovered = true;
             }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TextListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TextListEntry.java
@@ -23,6 +23,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import me.shedaniel.clothconfig2.gui.AbstractConfigScreen;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -36,12 +37,14 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
 public class TextListEntry extends TooltipListEntry<Object> {
     public static final int LINE_HEIGHT = 12;
+    public static final int DISABLED_COLOR = Objects.requireNonNull(ChatFormatting.DARK_GRAY.getColor());
     private final Font textRenderer = Minecraft.getInstance().font;
     private final int color;
     private final Component text;
@@ -81,8 +84,9 @@ public class TextListEntry extends TooltipListEntry<Object> {
             this.savedY = y;
         }
         int yy = y + 7;
+        int textColor = isEnabled() ? color : DISABLED_COLOR;
         for (FormattedCharSequence string : wrappedLines) {
-            Minecraft.getInstance().font.drawShadow(matrices, string, x, yy, color);
+            Minecraft.getInstance().font.drawShadow(matrices, string, x, yy, textColor);
             yy += Minecraft.getInstance().font.lineHeight + 3;
         }
         

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TooltipListEntry.java
@@ -25,15 +25,14 @@ import me.shedaniel.clothconfig2.api.Tooltip;
 import me.shedaniel.math.Point;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.FormattedCharSequence;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Environment(EnvType.CLIENT)
 public abstract class TooltipListEntry<T> extends AbstractConfigListEntry<T> {
@@ -56,21 +55,25 @@ public abstract class TooltipListEntry<T> extends AbstractConfigListEntry<T> {
     public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
         super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
         if (isMouseInside(mouseX, mouseY, x, y, entryWidth, entryHeight)) {
-            Optional<Component[]> tooltip = getTooltip(mouseX, mouseY);
-            if (tooltip.isPresent() && tooltip.get().length > 0)
-                addTooltip(Tooltip.of(new Point(mouseX, mouseY), postProcessTooltip(tooltip.get())));
+            getTooltip(mouseX, mouseY)
+                    .map(lines -> Tooltip.of(new Point(mouseX, mouseY), wrapLinesToScreen(lines)))
+                    .ifPresent(this::addTooltip);
         }
     }
     
-    private FormattedCharSequence[] postProcessTooltip(Component[] tooltip) {
-        return Arrays.stream(tooltip).flatMap(component -> Minecraft.getInstance().font.split(component, getConfigScreen().width).stream())
-                .toArray(FormattedCharSequence[]::new);
-    }
-    
     public Optional<Component[]> getTooltip() {
-        if (tooltipSupplier != null)
-            return tooltipSupplier.get();
-        return Optional.empty();
+        Stream<Component> tooltipStream = Stream.ofNullable(tooltipSupplier)
+                .map(Supplier::get)
+                .flatMap(Optional::stream)
+                .flatMap(Arrays::stream);
+        
+        @Nullable Component disabled = this.isEnabled() ? null : Component.translatable("text.cloth-config.disabled_tooltip");
+        
+        Component[] lines = Stream.concat(tooltipStream, Stream.ofNullable(disabled))
+                .toArray(Component[]::new);
+        
+        return lines.length < 1 ? Optional.empty() : Optional.of(lines);
+        
     }
     
     public Optional<Component[]> getTooltip(int mouseX, int mouseY) {
@@ -85,5 +88,5 @@ public abstract class TooltipListEntry<T> extends AbstractConfigListEntry<T> {
     public void setTooltipSupplier(@Nullable Supplier<Optional<Component[]>> tooltipSupplier) {
         this.tooltipSupplier = tooltipSupplier;
     }
-    
+
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicElementListWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicElementListWidget.java
@@ -66,6 +66,62 @@ public abstract class DynamicElementListWidget<E extends DynamicElementListWidge
         public void setFocused(GuiEventListener element_1) {
             this.focused = element_1;
         }
+        
+        @Override
+        public boolean mouseClicked(double d, double e, int i) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.mouseClicked(d, e, i);
+        }
+        
+        @Override
+        public boolean mouseReleased(double d, double e, int i) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.mouseReleased(d, e, i);
+        }
+        
+        @Override
+        public boolean mouseDragged(double d, double e, int i, double f, double g) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.mouseDragged(d, e, i, f, g);
+        }
+        
+        @Override
+        public boolean mouseScrolled(double d, double e, double f) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.mouseScrolled(d, e, f);
+        }
+        
+        @Override
+        public boolean keyPressed(int i, int j, int k) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.keyPressed(i, j, k);
+        }
+        
+        @Override
+        public boolean keyReleased(int i, int j, int k) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.keyReleased(i, j, k);
+        }
+        
+        @Override
+        public boolean charTyped(char c, int i) {
+            if (!isEnabled()) {
+                return false;
+            }
+            return ContainerEventHandler.super.charTyped(c, i);
+        }
     }
 }
 

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicEntryListWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicEntryListWidget.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Matrix4f;
-import me.shedaniel.clothconfig2.api.ScissorsHandler;
+import me.shedaniel.clothconfig2.api.*;
 import me.shedaniel.math.Rectangle;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -40,18 +40,17 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Environment(EnvType.CLIENT)
-public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.Entry<E>> extends AbstractContainerEventHandler implements Widget, NarratableEntry {
+public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.Entry<E>> extends AbstractContainerEventHandler implements TickableWidget, Widget, NarratableEntry {
     protected static final int DRAG_OUTSIDE = -2;
     protected final Minecraft client;
     private final List<E> entries = new Entries();
+    private List<E> visibleEntries = Collections.emptyList();
     public int width;
     public int height;
     public int top;
@@ -79,6 +78,25 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
         this.left = 0;
         this.right = width;
         this.backgroundLocation = backgroundLocation;
+    }
+    
+    /**
+     * Get all visible children. I.e. hidden config entries are filtered out.
+     * 
+     * <p> Note: this isn't thread safe, since the visible children list is
+     * updated when calling {@link #tick()}.
+     * 
+     * @return an unmodifiable {@link List} of visible entries
+     */
+    @ApiStatus.Experimental
+    public List<E> visibleChildren() {
+        return this.visibleEntries;
+    }
+    
+    private void updateVisibleChildren() {
+        this.visibleEntries = this.children().stream()
+                .filter(HideableWidget::isDisplayed)
+                .toList();
     }
     
     public void setRenderSelection(boolean boolean_1) {
@@ -117,7 +135,7 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected void narrateListElementPosition(NarrationElementOutput narrationElementOutput, E entry) {
-        List<E> list = this.children();
+        List<E> list = this.visibleChildren();
         if (list.size() > 1) {
             int i = list.indexOf(entry);
             if (i != -1) {
@@ -151,7 +169,7 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected E getItem(int index) {
-        return this.children().get(index);
+        return this.visibleChildren().get(index);
     }
     
     protected int addItem(E item) {
@@ -160,11 +178,11 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected int getItemCount() {
-        return this.children().size();
+        return this.visibleChildren().size();
     }
     
     protected boolean isSelected(int index) {
-        return Objects.equals(this.getSelectedItem(), this.children().get(index));
+        return Objects.equals(this.getSelectedItem(), this.getItem(index));
     }
     
     protected final E getItemAtPosition(double mouseX, double mouseY) {
@@ -172,17 +190,29 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
         int minX = listMiddleX - this.getItemWidth() / 2;
         int maxX = listMiddleX + this.getItemWidth() / 2;
         int currentY = Mth.floor(mouseY - (double) this.top) - this.headerHeight + (int) this.getScroll() - 4;
+        
+        // Check if we can return early
+        if ((double) this.getScrollbarPosition() <= mouseX) {
+            return null;
+        } else if (mouseX < minX) {
+            return null;
+        } else if (mouseX > maxX) {
+            return null;
+        } else if (currentY < 0) {
+            return null;
+        }
+        
+        // Otherwise look for the selected item
+        E itemAtPosition = null;
         int itemY = 0;
-        int itemIndex = -1;
-        for (int i = 0; i < children().size(); i++) {
-            E item = getItem(i);
+        for (E item : visibleChildren()) {
             itemY += item.getItemHeight();
             if (itemY > currentY) {
-                itemIndex = i;
+                itemAtPosition = item;
                 break;
             }
         }
-        return mouseX < (double) this.getScrollbarPosition() && mouseX >= minX && mouseX <= maxX && itemIndex >= 0 && currentY >= 0 && itemIndex < this.getItemCount() ? this.children().get(itemIndex) : null;
+        return itemAtPosition;
     }
     
     public void updateSize(int width, int height, int top, int bottom) {
@@ -202,7 +232,7 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     protected int getMaxScrollPosition() {
         List<Integer> list = new ArrayList<>();
         int i = headerHeight;
-        for (E entry : children()) {
+        for (E entry : visibleChildren()) {
             i += entry.getItemHeight();
             if (entry.getMorePossibleHeight() >= 0) {
                 list.add(i + entry.getMorePossibleHeight());
@@ -213,6 +243,14 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected void clickedHeader(int int_1, int int_2) {
+    }
+    
+    @Override
+    public void tick() {
+        this.updateVisibleChildren();
+        for (E child : this.children()) {
+           child.tick();
+        }
     }
     
     protected void renderHeader(PoseStack matrices, int rowLeft, int startY, Tesselator tessellator) {
@@ -312,14 +350,21 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected void centerScrollOn(E item) {
-        double d = (this.bottom - this.top) / -2d;
-        for (int i = 0; i < this.children().indexOf(item) && i < this.getItemCount(); i++)
-            d += getItem(i).getItemHeight();
-        this.capYPosition(d);
+        List<E> children = this.visibleChildren();
+        double halfway = (this.bottom - this.top) / -2d;
+        int itemIndex = children.indexOf(item);
+        int i = 0;
+        for (E elm : children) {
+            if (i++ >= itemIndex) {
+                break;
+            }
+            halfway += elm.getItemHeight();
+        }
+        this.capYPosition(halfway);
     }
     
     protected void ensureVisible(E item) {
-        int rowTop = this.getRowTop(this.children().indexOf(item));
+        int rowTop = this.getRowTop(this.visibleChildren().indexOf(item));
         int int_2 = rowTop - this.top - 4 - item.getItemHeight();
         if (int_2 < 0)
             this.scroll(int_2);
@@ -409,7 +454,7 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     public boolean mouseScrolled(double double_1, double double_2, double double_3) {
-        for (E entry : children()) {
+        for (E entry : visibleChildren()) {
             if (entry.mouseScrolled(double_1, double_2, double_3)) {
                 return true;
             }
@@ -432,36 +477,39 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
         }
     }
     
-    protected void moveSelection(int int_1) {
-        if (!this.children().isEmpty()) {
-            int int_2 = this.children().indexOf(this.getSelectedItem());
-            int int_3 = Mth.clamp(int_2 + int_1, 0, this.getItemCount() - 1);
-            E itemListWidget$Item_1 = this.children().get(int_3);
-            this.selectItem(itemListWidget$Item_1);
-            this.ensureVisible(itemListWidget$Item_1);
+    protected void moveSelection(int shift) {
+        List<E> children = this.visibleChildren();
+        if (children.isEmpty()) {
+            return;
         }
-        
+        int selected = children.indexOf(this.getSelectedItem());
+        int index = Mth.clamp(selected + shift, 0, this.getItemCount() - 1);
+        E item = this.getItem(index);
+        this.selectItem(item);
+        this.ensureVisible(item);
     }
     
     public boolean isMouseOver(double double_1, double double_2) {
         return double_2 >= (double) this.top && double_2 <= (double) this.bottom && double_1 >= (double) this.left && double_1 <= (double) this.right;
     }
     
-    protected void renderList(PoseStack matrices, int startX, int startY, int int_3, int int_4, float float_1) {
-        hoveredItem = this.isMouseOver(int_3, int_4) ? this.getItemAtPosition(int_3, int_4) : null;
-        int itemCount = this.getItemCount();
+    protected void renderList(PoseStack matrices, int startX, int startY, int mouseX, int mouseY, float delta) {
         Tesselator tesselator = Tesselator.getInstance();
         BufferBuilder buffer = tesselator.getBuilder();
         
-        for (int renderIndex = 0; renderIndex < itemCount; ++renderIndex) {
-            E item = this.getItem(renderIndex);
-            int itemY = startY + headerHeight;
-            for (int i = 0; i < children().size() && i < renderIndex; i++)
-                itemY += children().get(i).getItemHeight();
+        hoveredItem = this.isMouseOver(mouseX, mouseY) ? this.getItemAtPosition(mouseX, mouseY) : null;
+        
+        int heights = 0; // itemHeight accumulator
+        int renderIndex = 0; // index is passed to render methods
+        for (E item : visibleChildren()) {
+            int itemY = startY + headerHeight + heights;
             int itemHeight = item.getItemHeight() - 4;
             int itemWidth = this.getItemWidth();
             int itemMinX, itemMaxX;
-            if (this.selectionVisible && this.isSelected(renderIndex)) {
+            boolean itemHovered = Objects.equals(this.hoveredItem, item);
+            
+            // if item is selected
+            if (this.selectionVisible && Objects.equals(this.selectedItem, item)) {
                 itemMinX = this.left + this.width / 2 - itemWidth / 2;
                 itemMaxX = itemMinX + itemWidth;
                 RenderSystem.disableTexture();
@@ -481,9 +529,14 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
                 RenderSystem.enableTexture();
             }
             
+            // Finally, call render
             int y = this.getRowTop(renderIndex);
             int x = this.getRowLeft();
-            renderItem(matrices, item, renderIndex, y, x, itemWidth, itemHeight, int_3, int_4, Objects.equals(hoveredItem, item), float_1);
+            renderItem(matrices, item, renderIndex, y, x, itemWidth, itemHeight, mouseX, mouseY, itemHovered, delta);
+            
+            // Update counter and accumulator
+            heights += item.getItemHeight();
+            renderIndex++;
         }
     }
     
@@ -496,10 +549,15 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     protected int getRowTop(int index) {
-        int integer = top + 4 - (int) this.getScroll() + headerHeight;
-        for (int i = 0; i < children().size() && i < index; i++)
-            integer += children().get(i).getItemHeight();
-        return integer;
+        int top = this.top + 4 - (int) this.getScroll() + headerHeight;
+        int i = 0;
+        for (E item : visibleChildren()) {
+            if (index <= i++) {
+                break;
+            }
+            top += item.getItemHeight(); 
+        }
+        return top;
     }
     
     protected boolean isFocused() {
@@ -521,18 +579,18 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
         tesselator.end();
     }
     
-    protected E remove(int int_1) {
-        E itemListWidget$Item_1 = this.children().get(int_1);
-        return this.removeEntry(this.children().get(int_1)) ? itemListWidget$Item_1 : null;
+    protected E remove(int index) {
+        E item = this.getItem(index);
+        return this.removeEntry(item) ? item : null;
     }
     
-    protected boolean removeEntry(E itemListWidget$Item_1) {
-        boolean boolean_1 = this.children().remove(itemListWidget$Item_1);
-        if (boolean_1 && itemListWidget$Item_1 == this.getSelectedItem()) {
+    protected boolean removeEntry(E entry) {
+        boolean removed = this.children().remove(entry);
+        if (removed && entry == this.getSelectedItem()) {
             this.selectItem(null);
         }
         
-        return boolean_1;
+        return removed;
     }
     
     public static final class SmoothScrollingSettings {
@@ -542,10 +600,16 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
     }
     
     @Environment(EnvType.CLIENT)
-    public abstract static class Entry<E extends Entry<E>> extends GuiComponent implements GuiEventListener {
+    public abstract static class Entry<E extends Entry<E>> extends GuiComponent implements GuiEventListener, TickableWidget, HideableWidget, DisableableWidget {
         @Deprecated DynamicEntryListWidget<E> parent;
         @Nullable
         private NarratableEntry lastNarratable;
+        @Nullable
+        protected Requirement enableRequirement = null;
+        @Nullable
+        protected Requirement displayRequirement = null;
+        protected boolean enabled = true;
+        protected boolean displayed = true;
         
         public Entry() {
         }
@@ -564,6 +628,36 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
             this.parent = parent;
         }
         
+        @Override
+        public boolean isEnabled() {
+            return isDisplayed() && enabled;
+        }
+        
+        @Override
+        public boolean isDisplayed() {
+            return displayed;
+        }
+        
+        @Override
+        public void setRequirement(@Nullable Requirement requirement) {
+            this.enableRequirement = requirement;
+        }
+        
+        @Override
+        public @Nullable Requirement getRequirement() {
+            return enableRequirement;
+        }
+        
+        @Override
+        public void setDisplayRequirement(@Nullable Requirement requirement) {
+            this.displayRequirement = requirement;
+        }
+        
+        @Override
+        public @Nullable Requirement getDisplayRequirement() {
+            return displayRequirement;
+        }
+        
         public abstract int getItemHeight();
         
         @Deprecated
@@ -572,6 +666,13 @@ public abstract class DynamicEntryListWidget<E extends DynamicEntryListWidget.En
         }
         
         public abstract List<? extends NarratableEntry> narratables();
+        
+        @Override
+        public void tick() {
+            // Check requirements
+            enabled = getRequirement() == null || getRequirement().check();
+            displayed = getDisplayRequirement() == null || getDisplayRequirement().check();
+        }
         
         void updateNarration(NarrationElementOutput narrationElementOutput) {
             List<? extends NarratableEntry> list = this.narratables();

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicNewSmoothScrollingEntryListWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicNewSmoothScrollingEntryListWidget.java
@@ -91,7 +91,7 @@ public abstract class DynamicNewSmoothScrollingEntryListWidget<E extends Dynamic
     
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
-        for (E entry : children()) {
+        for (E entry : visibleChildren()) {
             if (entry.mouseScrolled(mouseX, mouseY, amount)) {
                 return true;
             }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicSmoothScrollingEntryListWidget.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/DynamicSmoothScrollingEntryListWidget.java
@@ -90,7 +90,7 @@ public abstract class DynamicSmoothScrollingEntryListWidget<E extends DynamicEnt
     
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
-        for (E entry : children()) {
+        for (E entry : visibleChildren()) {
             if (entry.mouseScrolled(mouseX, mouseY, amount)) {
                 return true;
             }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
@@ -52,7 +52,7 @@ public class SearchFieldEntry extends AbstractConfigListEntry<Object> {
                     if (editBox.getValue().isEmpty())
                         return entries.iterator();
                     return Iterators.filter(entries.iterator(), entry -> {
-                        return screen.matchesSearch(entry.getSearchTags());
+                        return entry.isDisplayed() && screen.matchesSearch(entry.getSearchTags());
                     });
                 }
                 

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/BooleanToggleBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/BooleanToggleBuilder.java
@@ -109,7 +109,7 @@ public class BooleanToggleBuilder extends AbstractFieldBuilder<Boolean, BooleanL
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/ColorFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/ColorFieldBuilder.java
@@ -127,7 +127,7 @@ public class ColorFieldBuilder extends AbstractFieldBuilder<Integer, ColorEntry,
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleFieldBuilder.java
@@ -114,7 +114,7 @@ public class DoubleFieldBuilder extends AbstractRangeFieldBuilder<Double, Double
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleListBuilder.java
@@ -162,7 +162,7 @@ public class DoubleListBuilder extends AbstractRangeListBuilder<Double, DoubleLi
         entry.setRemoveTooltip(getRemoveTooltip());
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
@@ -127,7 +127,7 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>,
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
         entry.setSuggestionMode(suggestionMode);
-        return entry;
+        return finishBuilding(entry);
     }
     
     public static class TopCellElementBuilder {

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/EnumSelectorBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/EnumSelectorBuilder.java
@@ -103,7 +103,7 @@ public class EnumSelectorBuilder<T extends Enum<?>> extends AbstractFieldBuilder
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FieldBuilder.java
@@ -20,9 +20,12 @@
 package me.shedaniel.clothconfig2.impl.builders;
 
 import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import me.shedaniel.clothconfig2.api.Requirement;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,6 +41,8 @@ public abstract class FieldBuilder<T, A extends AbstractConfigListEntry, SELF ex
     protected boolean requireRestart = false;
     @Nullable protected Supplier<T> defaultValue = null;
     @Nullable protected Function<T, Optional<Component>> errorSupplier;
+    @Nullable protected Requirement enableRequirement = null;
+    @Nullable protected Requirement displayRequirement = null;
     
     protected FieldBuilder(Component resetButtonKey, Component fieldNameKey) {
         this.resetButtonKey = Objects.requireNonNull(resetButtonKey);
@@ -58,6 +63,25 @@ public abstract class FieldBuilder<T, A extends AbstractConfigListEntry, SELF ex
     @NotNull
     public abstract A build();
     
+    /**
+     * Finishes building the given {@link AbstractConfigListEntry config entry} by applying anything defined in this abstract class.
+     * <br><br>
+     * Should be used by implementations of {@link #build()}.
+     *
+     * @param gui the config entry to finish building
+     * @return the mutated config entry
+     */
+    @Contract(value = "_ -> param1", mutates = "param1")
+    protected A finishBuilding(A gui) {
+        if (gui == null)
+            return null;
+        if (enableRequirement != null)
+            gui.setRequirement(enableRequirement);
+        if (displayRequirement != null)
+            gui.setDisplayRequirement(displayRequirement);
+        return gui;
+    }
+    
     @NotNull
     public final Component getFieldNameKey() {
         return fieldNameKey;
@@ -74,5 +98,41 @@ public abstract class FieldBuilder<T, A extends AbstractConfigListEntry, SELF ex
     
     public void requireRestart(boolean requireRestart) {
         this.requireRestart = requireRestart;
+    }
+    
+    /**
+     * Set a requirement that controls whether the config entry gui is enabled.
+     * 
+     * <p>If an enablement requirement is already set, it will be overwritten.
+     * 
+     * <p>If the requirement returns {@code true}, the config entry will be enabled.
+     *    If the requirement returns {@code false}, the config entry will be disabled.
+     *
+     * @see Requirement 
+     */
+    @Contract(mutates = "this")
+    @ApiStatus.Experimental
+    public final SELF setRequirement(Requirement requirement) {
+        @SuppressWarnings("unchecked") SELF self = (SELF) this;
+        enableRequirement = requirement;
+        return self;
+    }
+    
+    /**
+     * Set a requirement that controls whether the config entry gui is displayed.
+     *
+     * <p>If a display requirement is already set, it will be overwritten.
+     * 
+     * <p>If the requirement returns {@code true}, the config entry will be displayed.
+     *    If the requirement returns {@code false}, the config entry will be hidden.
+     *
+     * @see Requirement 
+     */
+    @Contract(mutates = "this")
+    @ApiStatus.Experimental
+    public final SELF setDisplayRequirement(Requirement requirement) {
+        @SuppressWarnings("unchecked") SELF self = (SELF) this;
+        displayRequirement = requirement;
+        return self;
     }
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatFieldBuilder.java
@@ -113,7 +113,7 @@ public class FloatFieldBuilder extends AbstractRangeFieldBuilder<Float, FloatLis
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatListBuilder.java
@@ -162,7 +162,7 @@ public class FloatListBuilder extends AbstractRangeListBuilder<Float, FloatListL
         entry.setRemoveTooltip(getRemoveTooltip());
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntFieldBuilder.java
@@ -110,7 +110,7 @@ public class IntFieldBuilder extends AbstractRangeFieldBuilder<Integer, IntegerL
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntListBuilder.java
@@ -163,7 +163,7 @@ public class IntListBuilder extends AbstractRangeListBuilder<Integer, IntegerLis
         entry.setRemoveTooltip(getRemoveTooltip());
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/IntSliderBuilder.java
@@ -119,7 +119,7 @@ public class IntSliderBuilder extends AbstractSliderFieldBuilder<Integer, Intege
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/KeyCodeBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/KeyCodeBuilder.java
@@ -143,7 +143,7 @@ public class KeyCodeBuilder extends FieldBuilder<ModifierKeyCode, KeyCodeEntry, 
         entry.setAllowKey(allowKey);
         entry.setAllowMouse(allowMouse);
         entry.setAllowModifiers(allowModifiers);
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongFieldBuilder.java
@@ -113,7 +113,7 @@ public class LongFieldBuilder extends AbstractRangeFieldBuilder<Long, LongListEn
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongListBuilder.java
@@ -162,7 +162,7 @@ public class LongListBuilder extends AbstractRangeListBuilder<Long, LongListList
         entry.setRemoveTooltip(getRemoveTooltip());
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/LongSliderBuilder.java
@@ -99,7 +99,7 @@ public class LongSliderBuilder extends AbstractSliderFieldBuilder<Long, LongSlid
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/SelectorBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/SelectorBuilder.java
@@ -100,7 +100,7 @@ public class SelectorBuilder<T> extends AbstractFieldBuilder<T, SelectionListEnt
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringFieldBuilder.java
@@ -91,7 +91,7 @@ public class StringFieldBuilder extends AbstractFieldBuilder<String, StringListE
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/StringListBuilder.java
@@ -138,7 +138,7 @@ public class StringListBuilder extends AbstractListBuilder<String, StringListLis
         entry.setRemoveTooltip(getRemoveTooltip());
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/SubCategoryBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/SubCategoryBuilder.java
@@ -78,7 +78,7 @@ public class SubCategoryBuilder extends FieldBuilder<List<AbstractConfigListEntr
     public SubCategoryListEntry build() {
         SubCategoryListEntry entry = new SubCategoryListEntry(getFieldNameKey(), entries, expanded);
         entry.setTooltipSupplier(() -> tooltipSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
     @Override

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextDescriptionBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextDescriptionBuilder.java
@@ -69,7 +69,7 @@ public class TextDescriptionBuilder extends FieldBuilder<Component, TextListEntr
     @NotNull
     @Override
     public TextListEntry build() {
-        return new TextListEntry(getFieldNameKey(), value, color, tooltipSupplier);
+        return finishBuilding(new TextListEntry(getFieldNameKey(), value, color, tooltipSupplier));
     }
     
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextFieldBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/TextFieldBuilder.java
@@ -91,7 +91,7 @@ public class TextFieldBuilder extends AbstractFieldBuilder<String, StringListEnt
         entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
         if (errorSupplier != null)
             entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
-        return entry;
+        return finishBuilding(entry);
     }
     
 }

--- a/common/src/main/resources/assets/cloth-config2/lang/en_us.json
+++ b/common/src/main/resources/assets/cloth-config2/lang/en_us.json
@@ -33,6 +33,7 @@
     "text.cloth-config.boolean.value.true": "§aYes",
     "text.cloth-config.boolean.value.false": "§cNo",
     "text.cloth-config.dropdown.value.unknown": "§cNo suggestions",
+    "text.cloth-config.disabled_tooltip": "Disabled (requirements not met)",
     "modifier.cloth-config.alt": "Alt + %s",
     "modifier.cloth-config.ctrl": "Ctrl + %s",
     "modifier.cloth-config.shift": "Shift + %s",


### PR DESCRIPTION
Following on from my initial draft PR #195, here's a subset of the changes focused on adding dependency support to cloth config.

I identified the main cause of complexity in the draft PR was auto-generating human readable descriptions of potentially complex dependencies. In hindsight, the result isn't worth the added complexity, instead it is recommended that users write their own dependency descriptions in tooltips or labels.

This PR does add a simple "Dependencies not met" line to the tooltip when `isEnabled()` is `false`. This could be removed/reformatted/reworded depending on your preference.

~~Currently, the `Dependency` may be checked multiple times per frame. If this proves performance intenseive, it may make sense to instead check once-per-tick on the main thread and store the result in an `AtomicBoolean` to reference from the render thread.~~ _implemented_

I plan to add an implementation for autoconfig in a follow up PR, based on what I have currently in the initial draft, but ideally this should be merged first - or at least the design agreed upon.

Fixes #26