### PR TITLE
Add float and double sliders

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -52,6 +52,20 @@ public class ConfigEntry {
     }
     
     /**
+     * Applies to float and double fields.
+     * In a future version it will enforce bounds at deserialization.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface BoundedFloating {
+        double min() default 0;
+
+        double max();
+        
+        int precision() default 2;
+    }
+    
+    /**
      * Applies to int fields.
      * Sets the GUI to a color picker.
      * In a future version it will enforce bounds at deserialization.
@@ -61,18 +75,6 @@ public class ConfigEntry {
     public @interface ColorPicker {
         boolean allowAlpha() default false;
     }
-
-//    /**
-//     * Applies to float and double fields.
-//     * In a future version it will enforce bounds at deserialization.
-//     */
-//    @Retention(RetentionPolicy.RUNTIME)
-//    @Target(ElementType.FIELD)
-//    public @interface BoundedFloating {
-//        double min() default 0;
-//
-//        double max();
-//    }
     
     public static class Gui {
         private Gui() {

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -132,6 +132,28 @@ public class DefaultGuiProviders {
         
         registry.registerAnnotationProvider(
                 (i18n, field, config, defaults, guiProvider) -> {
+                    ConfigEntry.BoundedFloating bounds
+                            = field.getAnnotation(ConfigEntry.BoundedFloating.class);
+                    
+                    return Collections.singletonList(
+                            ENTRY_BUILDER.startDoubleSlider(
+                                            Component.translatable(i18n),
+                                            getUnsafely(field, config, 0L),
+                                            bounds.min(),
+                                            bounds.max(),
+                                            bounds.precision()
+                                    )
+                                    .setDefaultValue(() -> getUnsafely(field, defaults))
+                                    .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                                    .build()
+                    );
+                },
+                field -> field.getType() == double.class || field.getType() == Double.class,
+                ConfigEntry.BoundedFloating.class
+        );
+        
+        registry.registerAnnotationProvider(
+                (i18n, field, config, defaults, guiProvider) -> {
                     ConfigEntry.ColorPicker colorPicker
                             = field.getAnnotation(ConfigEntry.ColorPicker.class);
                     

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiProviders.java
@@ -110,6 +110,28 @@ public class DefaultGuiProviders {
         
         registry.registerAnnotationProvider(
                 (i18n, field, config, defaults, guiProvider) -> {
+                    ConfigEntry.BoundedFloating bounds
+                            = field.getAnnotation(ConfigEntry.BoundedFloating.class);
+                    
+                    return Collections.singletonList(
+                            ENTRY_BUILDER.startFloatSlider(
+                                            Component.translatable(i18n),
+                                            getUnsafely(field, config, 0L),
+                                            (float) bounds.min(),
+                                            (float) bounds.max(),
+                                            bounds.precision()
+                                    )
+                                    .setDefaultValue(() -> getUnsafely(field, defaults))
+                                    .setSaveConsumer(newValue -> setUnsafely(field, config, newValue))
+                                    .build()
+                    );
+                },
+                field -> field.getType() == float.class || field.getType() == Float.class,
+                ConfigEntry.BoundedFloating.class
+        );
+        
+        registry.registerAnnotationProvider(
+                (i18n, field, config, defaults, guiProvider) -> {
                     ConfigEntry.ColorPicker colorPicker
                             = field.getAnnotation(ConfigEntry.ColorPicker.class);
                     

--- a/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
@@ -200,9 +200,9 @@ public class ClothConfigDemo {
                         () -> intDependency.getValue() > 70))
                 .build());
         
-        FloatSliderEntry floatSlider = entryBuilder.startFloatSlider(Component.literal("Select a float"), 10, 0, 10, 1).setSaveConsumer(number -> System.out.println("Float value set to " + number)).build();
+        FloatSliderEntry floatSlider = entryBuilder.startFloatSlider(Component.literal("Select a float"), 4.2f, 0, 10, 1).setSaveConsumer(number -> System.out.println("Float value set to " + number)).build();
         depends.add(floatSlider);
-        DoubleSliderEntry doubleSlider = entryBuilder.startDoubleSlider(Component.literal("Select a double"), 10, 0, 10, 10).setSaveConsumer(number -> System.out.println("Double value set to " + number)).build();
+        DoubleSliderEntry doubleSlider = entryBuilder.startDoubleSlider(Component.literal("Select a double"), 3.1415926535, 0, 10, 10).setSaveConsumer(number -> System.out.println("Double value set to " + number)).build();
         depends.add(doubleSlider);
     
         testing.addEntry(depends.build());

--- a/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
@@ -200,8 +200,10 @@ public class ClothConfigDemo {
                         () -> intDependency.getValue() > 70))
                 .build());
         
-        FloatSliderEntry floatSlider = entryBuilder.startFloatSlider(Component.literal("Select a float"), 10, 0, 10, 4).setSaveConsumer(number -> System.out.println("floating value set to " + number)).build();
+        FloatSliderEntry floatSlider = entryBuilder.startFloatSlider(Component.literal("Select a float"), 10, 0, 10, 1).setSaveConsumer(number -> System.out.println("Float value set to " + number)).build();
         depends.add(floatSlider);
+        DoubleSliderEntry doubleSlider = entryBuilder.startDoubleSlider(Component.literal("Select a double"), 10, 0, 10, 10).setSaveConsumer(number -> System.out.println("Double value set to " + number)).build();
+        depends.add(doubleSlider);
     
         testing.addEntry(depends.build());
        

--- a/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/ClothConfigDemo.java
@@ -199,6 +199,9 @@ public class ClothConfigDemo {
                         () -> intDependency.getValue() < -70,
                         () -> intDependency.getValue() > 70))
                 .build());
+        
+        FloatSliderEntry floatSlider = entryBuilder.startFloatSlider(Component.literal("Select a float"), 10, 0, 10, 4).setSaveConsumer(number -> System.out.println("floating value set to " + number)).build();
+        depends.add(floatSlider);
     
         testing.addEntry(depends.build());
        

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
@@ -104,6 +104,8 @@ public interface ConfigEntryBuilder {
     
     LongSliderBuilder startLongSlider(Component fieldNameKey, long value, long min, long max);
     
+    FloatSliderBuilder startFloatSlider(Component fieldNameKey, float value, float min, float max, int precision);
+    
     KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value);
     
     default KeyCodeBuilder startKeyCodeField(Component fieldNameKey, InputConstants.Key value) {

--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
@@ -106,6 +106,8 @@ public interface ConfigEntryBuilder {
     
     FloatSliderBuilder startFloatSlider(Component fieldNameKey, float value, float min, float max, int precision);
     
+    DoubleSliderBuilder startDoubleSlider(Component fieldNameKey, double value, double min, double max, int precision);
+    
     KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value);
     
     default KeyCodeBuilder startKeyCodeField(Component fieldNameKey, InputConstants.Key value) {

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DoubleSliderEntry.java
@@ -41,33 +41,33 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
-public class FloatSliderEntry extends TooltipListEntry<Float> {
+public class DoubleSliderEntry extends TooltipListEntry<Double> {
     
     protected Slider sliderWidget;
     protected Button resetButton;
-    protected Float value;
-    protected final Float orginial;
-    private float minimum, maximum;
+    protected Double value;
+    protected final Double orginial;
+    private Double minimum, maximum;
     private int precision;
-    private final Supplier<Float> defaultValue;
-    private Function<Float, Component> textGetter = value -> Component.literal(String.format("Value: %." + precision + "f", value));
+    private final Supplier<Double> defaultValue;
+    private Function<Double, Component> textGetter = value -> Component.literal(String.format("Value: %." + precision + "f", value));
     private final List<AbstractWidget> widgets;
     
     @ApiStatus.Internal
     @Deprecated
-    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer) {
+    public DoubleSliderEntry(Component fieldName, double minimum, double maximum, double value, int precision, Component resetButtonKey, Supplier<Double> defaultValue, Consumer<Double> saveConsumer) {
         this(fieldName, minimum, maximum, value, precision, resetButtonKey, defaultValue, saveConsumer, null);
     }
     
     @ApiStatus.Internal
     @Deprecated
-    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier) {
+    public DoubleSliderEntry(Component fieldName, double minimum, double maximum, double value, int precision, Component resetButtonKey, Supplier<Double> defaultValue, Consumer<Double> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier) {
         this(fieldName, minimum, maximum, value, precision, resetButtonKey, defaultValue, saveConsumer, tooltipSupplier, false);
     }
     
     @ApiStatus.Internal
     @Deprecated
-    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
+    public DoubleSliderEntry(Component fieldName, double minimum, double maximum, double value, int precision, Component resetButtonKey, Supplier<Double> defaultValue, Consumer<Double> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
         super(fieldName, tooltipSupplier, requiresRestart);
         this.orginial = value;
         this.defaultValue = defaultValue;
@@ -80,34 +80,34 @@ public class FloatSliderEntry extends TooltipListEntry<Float> {
         this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
             setValue(defaultValue.get());
         });
-        this.sliderWidget.setMessage(textGetter.apply(FloatSliderEntry.this.value));
+        this.sliderWidget.setMessage(textGetter.apply(DoubleSliderEntry.this.value));
         this.widgets = Lists.newArrayList(sliderWidget, resetButton);
     }
     
-    public Function<Float, Component> getTextGetter() {
+    public Function<Double, Component> getTextGetter() {
         return textGetter;
     }
     
-    public FloatSliderEntry setTextGetter(Function<Float, Component> textGetter) {
+    public DoubleSliderEntry setTextGetter(Function<Double, Component> textGetter) {
         this.textGetter = textGetter;
-        this.sliderWidget.setMessage(textGetter.apply(FloatSliderEntry.this.value));
+        this.sliderWidget.setMessage(textGetter.apply(DoubleSliderEntry.this.value));
         return this;
     }
     
     @Override
-    public Float getValue() {
+    public Double getValue() {
         return value;
     }
     
     @Deprecated
-    public void setValue(float value) {
+    public void setValue(double value) {
         sliderWidget.setValue((Mth.clamp(value, minimum, maximum) - minimum) / (double) Math.abs(maximum - minimum));
         this.value = roundNumber(Math.min(Math.max(value, minimum), maximum));
         sliderWidget.updateMessage();
     }
     
-    private float roundNumber(double value) {
-        return (float) (Math.round(value * Math.pow(10, this.precision)) / Math.pow(10, this.precision));
+    private double roundNumber(double value) {
+        return (Math.round(value * Math.pow(10, this.precision)) / Math.pow(10, this.precision));
     }
     
     @Override
@@ -116,7 +116,7 @@ public class FloatSliderEntry extends TooltipListEntry<Float> {
     }
     
     @Override
-    public Optional<Float> getDefaultValue() {
+    public Optional<Double> getDefaultValue() {
         return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
     }
     
@@ -130,17 +130,17 @@ public class FloatSliderEntry extends TooltipListEntry<Float> {
         return widgets;
     }
     
-    public FloatSliderEntry setMaximum(float maximum) {
+    public DoubleSliderEntry setMaximum(double maximum) {
         this.maximum = maximum;
         return this;
     }
     
-    public FloatSliderEntry setMinimum(float minimum) {
+    public DoubleSliderEntry setMinimum(double minimum) {
         this.minimum = minimum;
         return this;
     }
     
-    public FloatSliderEntry setPrecision(int precision) {
+    public DoubleSliderEntry setPrecision(int precision) {
         this.precision = precision;
         return this;
     }
@@ -175,12 +175,12 @@ public class FloatSliderEntry extends TooltipListEntry<Float> {
         
         @Override
         public void updateMessage() {
-            setMessage(textGetter.apply(FloatSliderEntry.this.value));
+            setMessage(textGetter.apply(DoubleSliderEntry.this.value));
         }
         
         @Override
         protected void applyValue() {
-            FloatSliderEntry.this.value = roundNumber((minimum + Math.abs(maximum - minimum) * value));
+            DoubleSliderEntry.this.value = roundNumber((minimum + Math.abs(maximum - minimum) * value));
         }
         
         @Override

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/FloatSliderEntry.java
@@ -1,0 +1,213 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.clothconfig2.gui.entries;
+
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class FloatSliderEntry extends TooltipListEntry<Float> {
+    
+    protected Slider sliderWidget;
+    protected Button resetButton;
+    protected Float value;
+    protected final Float orginial;
+    private float minimum, maximum;
+    private int precision;
+    private final Supplier<Float> defaultValue;
+    private Function<Float, Component> textGetter = value -> Component.literal(String.format("Value: %." + precision + "f", value));
+    private final List<AbstractWidget> widgets;
+    
+    @ApiStatus.Internal
+    @Deprecated
+    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer) {
+        this(fieldName, minimum, maximum, value, precision, resetButtonKey, defaultValue, saveConsumer, null);
+    }
+    
+    @ApiStatus.Internal
+    @Deprecated
+    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier) {
+        this(fieldName, minimum, maximum, value, precision, resetButtonKey, defaultValue, saveConsumer, tooltipSupplier, false);
+    }
+    
+    @ApiStatus.Internal
+    @Deprecated
+    public FloatSliderEntry(Component fieldName, float minimum, float maximum, float value, int precision, Component resetButtonKey, Supplier<Float> defaultValue, Consumer<Float> saveConsumer, Supplier<Optional<Component[]>> tooltipSupplier, boolean requiresRestart) {
+        super(fieldName, tooltipSupplier, requiresRestart);
+        this.orginial = value;
+        this.defaultValue = defaultValue;
+        this.value = value;
+        this.saveCallback = saveConsumer;
+        this.maximum = maximum;
+        this.minimum = minimum;
+        this.precision = precision;
+        this.sliderWidget = new Slider(0, 0, 152, 20, ((double) this.value - minimum) / Math.abs(maximum - minimum));
+        this.resetButton = new Button(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20, resetButtonKey, widget -> {
+            setValue(defaultValue.get());
+        });
+        this.sliderWidget.setMessage(textGetter.apply(FloatSliderEntry.this.value));
+        this.widgets = Lists.newArrayList(sliderWidget, resetButton);
+    }
+    
+    public Function<Float, Component> getTextGetter() {
+        return textGetter;
+    }
+    
+    public FloatSliderEntry setTextGetter(Function<Float, Component> textGetter) {
+        this.textGetter = textGetter;
+        this.sliderWidget.setMessage(textGetter.apply(FloatSliderEntry.this.value));
+        return this;
+    }
+    
+    @Override
+    public Float getValue() {
+        return value;
+    }
+    
+    @Deprecated
+    public void setValue(float value) {
+        sliderWidget.setValue((Mth.clamp(value, minimum, maximum) - minimum) / (double) Math.abs(maximum - minimum));
+        this.value = roundNumber(Math.min(Math.max(value, minimum), maximum));
+        sliderWidget.updateMessage();
+    }
+    
+    private float roundNumber(double value) {
+        return (float) (Math.round(value * Math.pow(10, this.precision)) / Math.pow(10, this.precision));
+    }
+    
+    @Override
+    public boolean isEdited() {
+        return super.isEdited() || getValue() != orginial;
+    }
+    
+    @Override
+    public Optional<Float> getDefaultValue() {
+        return defaultValue == null ? Optional.empty() : Optional.ofNullable(defaultValue.get());
+    }
+    
+    @Override
+    public List<? extends GuiEventListener> children() {
+        return widgets;
+    }
+    
+    @Override
+    public List<? extends NarratableEntry> narratables() {
+        return widgets;
+    }
+    
+    public FloatSliderEntry setMaximum(float maximum) {
+        this.maximum = maximum;
+        return this;
+    }
+    
+    public FloatSliderEntry setMinimum(float minimum) {
+        this.minimum = minimum;
+        return this;
+    }
+    
+    public FloatSliderEntry setPrecision(int precision) {
+        this.precision = precision;
+        return this;
+    }
+    
+    @Override
+    public void render(PoseStack matrices, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
+        super.render(matrices, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
+        Window window = Minecraft.getInstance().getWindow();
+        this.resetButton.active = isEditable() && getDefaultValue().isPresent() && defaultValue.get() != value;
+        this.resetButton.y = y;
+        this.sliderWidget.active = isEditable();
+        this.sliderWidget.y = y;
+        Component displayedFieldName = getDisplayedFieldName();
+        if (Minecraft.getInstance().font.isBidirectional()) {
+            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), window.getGuiScaledWidth() - x - Minecraft.getInstance().font.width(displayedFieldName), y + 6, getPreferredTextColor());
+            this.resetButton.x = x;
+            this.sliderWidget.x = x + resetButton.getWidth() + 1;
+        } else {
+            Minecraft.getInstance().font.drawShadow(matrices, displayedFieldName.getVisualOrderText(), x, y + 6, getPreferredTextColor());
+            this.resetButton.x = x + entryWidth - resetButton.getWidth();
+            this.sliderWidget.x = x + entryWidth - 150;
+        }
+        this.sliderWidget.setWidth(150 - resetButton.getWidth() - 2);
+        resetButton.render(matrices, mouseX, mouseY, delta);
+        sliderWidget.render(matrices, mouseX, mouseY, delta);
+    }
+    
+    private class Slider extends AbstractSliderButton {
+        protected Slider(int int_1, int int_2, int int_3, int int_4, double double_1) {
+            super(int_1, int_2, int_3, int_4, Component.empty(), double_1);
+        }
+        
+        @Override
+        public void updateMessage() {
+            setMessage(textGetter.apply(FloatSliderEntry.this.value));
+        }
+        
+        @Override
+        protected void applyValue() {
+            FloatSliderEntry.this.value = roundNumber((float) (minimum + Math.abs(maximum - minimum) * value));
+        }
+        
+        @Override
+        public boolean keyPressed(int int_1, int int_2, int int_3) {
+            if (!isEditable())
+                return false;
+            return super.keyPressed(int_1, int_2, int_3);
+        }
+        
+        @Override
+        public boolean mouseDragged(double double_1, double double_2, int int_1, double double_3, double double_4) {
+            if (!isEditable())
+                return false;
+            return super.mouseDragged(double_1, double_2, int_1, double_3, double_4);
+        }
+        
+        public double getProgress() {
+            return value;
+        }
+        
+        public void setProgress(double progress) {
+            this.value = progress;
+        }
+        
+        public void setValue(double value) {
+            this.value = value;
+        }
+    }
+    
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
@@ -167,6 +167,11 @@ public class ConfigEntryBuilderImpl implements ConfigEntryBuilder {
     }
     
     @Override
+    public FloatSliderBuilder startFloatSlider(Component fieldNameKey, float value, float min, float max, int precision) {
+        return new FloatSliderBuilder(resetButtonKey, fieldNameKey, value, min, max, precision);
+    }
+    
+    @Override
     public KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value) {
         return new KeyCodeBuilder(resetButtonKey, fieldNameKey, value);
     }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
@@ -172,6 +172,11 @@ public class ConfigEntryBuilderImpl implements ConfigEntryBuilder {
     }
     
     @Override
+    public DoubleSliderBuilder startDoubleSlider(Component fieldNameKey, double value, double min, double max, int precision) {
+        return new DoubleSliderBuilder(resetButtonKey, fieldNameKey, value, min, max, precision);
+    }
+    
+    @Override
     public KeyCodeBuilder startModifierKeyCodeField(Component fieldNameKey, ModifierKeyCode value) {
         return new KeyCodeBuilder(resetButtonKey, fieldNameKey, value);
     }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleSliderBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DoubleSliderBuilder.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.DoubleSliderEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class DoubleSliderBuilder extends AbstractSliderFieldBuilder<Double, DoubleSliderEntry, DoubleSliderBuilder> {
+    private int precision;
+    
+    public DoubleSliderBuilder(Component resetButtonKey, Component fieldNameKey, double value, double min, double max, int precision) {
+        super(resetButtonKey, fieldNameKey);
+        this.value = value;
+        this.max = max;
+        this.min = min;
+        this.precision = precision;
+    }
+    
+    @Override
+    public DoubleSliderBuilder setErrorSupplier(Function<Double, Optional<Component>> errorSupplier) {
+        return super.setErrorSupplier(errorSupplier);
+    }
+    
+    @Override
+    public DoubleSliderBuilder requireRestart() {
+        return super.requireRestart();
+    }
+    
+    @Override
+    public DoubleSliderBuilder setTextGetter(Function<Double, Component> textGetter) {
+        return super.setTextGetter(textGetter);
+    }
+    
+    @Override
+    public DoubleSliderBuilder setSaveConsumer(Consumer<Double> saveConsumer) {
+        return super.setSaveConsumer(saveConsumer);
+    }
+    
+    @Override
+    public DoubleSliderBuilder setDefaultValue(Supplier<Double> defaultValue) {
+        return super.setDefaultValue(defaultValue);
+    }
+    
+    public DoubleSliderBuilder setDefaultValue(double defaultValue) {
+        this.defaultValue = () -> defaultValue;
+        return this;
+    }
+    
+    @Override
+    public DoubleSliderBuilder setTooltipSupplier(Function<Double, Optional<Component[]>> tooltipSupplier) {
+        return super.setTooltipSupplier(tooltipSupplier);
+    }
+    
+    @Override
+    public DoubleSliderBuilder setTooltipSupplier(Supplier<Optional<Component[]>> tooltipSupplier) {
+        return super.setTooltipSupplier(tooltipSupplier);
+    }
+    
+    @Override
+    public DoubleSliderBuilder setTooltip(Optional<Component[]> tooltip) {
+        return super.setTooltip(tooltip);
+    }
+    
+    @Override
+    public DoubleSliderBuilder setTooltip(Component... tooltip) {
+        return super.setTooltip(tooltip);
+    }
+    
+    public DoubleSliderBuilder setMax(double max) {
+        this.max = max;
+        return this;
+    }
+    
+    public DoubleSliderBuilder setMin(double min) {
+        this.min = min;
+        return this;
+    }
+    
+    public DoubleSliderBuilder setPrecision(int precision) {
+        this.precision = precision;
+        return this;
+    }
+    
+    @Override
+    public DoubleSliderBuilder removeMin() {
+        return this;
+    }
+    
+    @Override
+    public DoubleSliderBuilder removeMax() {
+        return this;
+    }
+    
+    @NotNull
+    @Override
+    public DoubleSliderEntry build() {
+        DoubleSliderEntry entry = new DoubleSliderEntry(getFieldNameKey(), min, max, value, precision, getResetButtonKey(), defaultValue, getSaveConsumer(), null, isRequireRestart());
+        if (textGetter != null)
+            entry.setTextGetter(textGetter);
+        entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
+        if (errorSupplier != null)
+            entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
+        return finishBuilding(entry);
+    }    
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatSliderBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/FloatSliderBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.FloatSliderEntry;
+import me.shedaniel.clothconfig2.gui.entries.IntegerSliderEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class FloatSliderBuilder extends AbstractSliderFieldBuilder<Float, FloatSliderEntry, FloatSliderBuilder> {
+    private int precision;
+    
+    public FloatSliderBuilder(Component resetButtonKey, Component fieldNameKey, float value, float min, float max, int precision) {
+        super(resetButtonKey, fieldNameKey);
+        this.value = value;
+        this.max = max;
+        this.min = min;
+        this.precision = precision;
+    }
+    
+    @Override
+    public FloatSliderBuilder setErrorSupplier(Function<Float, Optional<Component>> errorSupplier) {
+        return super.setErrorSupplier(errorSupplier);
+    }
+    
+    @Override
+    public FloatSliderBuilder requireRestart() {
+        return super.requireRestart();
+    }
+    
+    @Override
+    public FloatSliderBuilder setTextGetter(Function<Float, Component> textGetter) {
+        return super.setTextGetter(textGetter);
+    }
+    
+    @Override
+    public FloatSliderBuilder setSaveConsumer(Consumer<Float> saveConsumer) {
+        return super.setSaveConsumer(saveConsumer);
+    }
+    
+    @Override
+    public FloatSliderBuilder setDefaultValue(Supplier<Float> defaultValue) {
+        return super.setDefaultValue(defaultValue);
+    }
+    
+    public FloatSliderBuilder setDefaultValue(float defaultValue) {
+        this.defaultValue = () -> defaultValue;
+        return this;
+    }
+    
+    @Override
+    public FloatSliderBuilder setTooltipSupplier(Function<Float, Optional<Component[]>> tooltipSupplier) {
+        return super.setTooltipSupplier(tooltipSupplier);
+    }
+    
+    @Override
+    public FloatSliderBuilder setTooltipSupplier(Supplier<Optional<Component[]>> tooltipSupplier) {
+        return super.setTooltipSupplier(tooltipSupplier);
+    }
+    
+    @Override
+    public FloatSliderBuilder setTooltip(Optional<Component[]> tooltip) {
+        return super.setTooltip(tooltip);
+    }
+    
+    @Override
+    public FloatSliderBuilder setTooltip(Component... tooltip) {
+        return super.setTooltip(tooltip);
+    }
+    
+    public FloatSliderBuilder setMax(float max) {
+        this.max = max;
+        return this;
+    }
+    
+    public FloatSliderBuilder setMin(float min) {
+        this.min = min;
+        return this;
+    }
+    
+    public FloatSliderBuilder setPrecision(int precision) {
+        this.precision = precision;
+        return this;
+    }
+    
+    @Override
+    public FloatSliderBuilder removeMin() {
+        return this;
+    }
+    
+    @Override
+    public FloatSliderBuilder removeMax() {
+        return this;
+    }
+    
+    @NotNull
+    @Override
+    public FloatSliderEntry build() {
+        FloatSliderEntry entry = new FloatSliderEntry(getFieldNameKey(), min, max, value, precision, getResetButtonKey(), defaultValue, getSaveConsumer(), null, isRequireRestart());
+        if (textGetter != null)
+            entry.setTextGetter(textGetter);
+        entry.setTooltipSupplier(() -> getTooltipSupplier().apply(entry.getValue()));
+        if (errorSupplier != null)
+            entry.setErrorSupplier(() -> errorSupplier.apply(entry.getValue()));
+        return finishBuilding(entry);
+    }    
+}


### PR DESCRIPTION
This adds float and double sliders as config entries.

The sliders work exactly like int sliders, but have a precision property that limits how many decimal places can be set.

![slider-demo](https://github.com/shedaniel/cloth-config/assets/69988482/93285649-be17-4ad8-bebd-1fa524e12626)

closes #94