### PR TITLE
Add GUI Registry pre/post hooks

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/AutoConfig.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/AutoConfig.java
@@ -21,6 +21,7 @@ package me.shedaniel.autoconfig;
 
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.gui.ConfigScreenProvider;
+import me.shedaniel.autoconfig.gui.DefaultGuiHooks;
 import me.shedaniel.autoconfig.gui.DefaultGuiProviders;
 import me.shedaniel.autoconfig.gui.DefaultGuiTransformers;
 import me.shedaniel.autoconfig.gui.registry.ComposedGuiRegistryAccess;
@@ -99,6 +100,6 @@ public class AutoConfig {
     @Environment(EnvType.CLIENT)
     private static class ClientOnly {
         private static final GuiRegistry defaultGuiRegistry =
-                DefaultGuiTransformers.apply(DefaultGuiProviders.apply(new GuiRegistry()));
+                DefaultGuiHooks.apply(DefaultGuiTransformers.apply(DefaultGuiProviders.apply(new GuiRegistry())));
     }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiHooks.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiHooks.java
@@ -20,14 +20,37 @@
 package me.shedaniel.autoconfig.gui;
 
 import me.shedaniel.autoconfig.gui.registry.GuiRegistry;
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Environment(EnvType.CLIENT)
 public class DefaultGuiHooks {
     private DefaultGuiHooks() {}
     
     public static GuiRegistry apply(GuiRegistry registry) {
+        
+        // FIXME Remove debugging code
+        registry.registerPreHook((guis, i18n, field, config, defaults, guiProvider) ->
+                System.out.println(String.join("\n",
+                        "Pre hook for `%s#%s`:".formatted(field.getDeclaringClass().getSimpleName(), field.getName()),
+                        " - \"%s\"".formatted(i18n)
+                )));
+        
+        registry.registerPostHook((guis, i18n, field, config, defaults, guiProvider) ->
+                System.out.println(Stream.concat(
+                        Stream.of(
+                                "Post hook for `%s#%s`:".formatted(field.getDeclaringClass().getSimpleName(), field.getName()),
+                                " - \"%s\"".formatted(i18n)
+                        ),
+                        guis.stream().map(Object::getClass).map(Class::getSimpleName).map(name -> " - " + name)
+                ).collect(Collectors.joining("\n"))));
+        
         return registry;
     }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiHooks.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiHooks.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.autoconfig.gui;
+
+import me.shedaniel.autoconfig.gui.registry.GuiRegistry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public class DefaultGuiHooks {
+    private DefaultGuiHooks() {}
+    
+    public static GuiRegistry apply(GuiRegistry registry) {
+        return registry;
+    }
+}

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/ComposedGuiRegistryAccess.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/ComposedGuiRegistryAccess.java
@@ -61,9 +61,9 @@ public class ComposedGuiRegistryAccess implements GuiRegistryAccess {
             Object defaults,
             GuiRegistryAccess registry
     ) {
-        for (GuiRegistryAccess child : children) {
-            guis = child.transform(guis, i18n, field, config, defaults, registry);
-        }
-        return guis;
+        return children.stream()
+                .reduce(guis,
+                        (prevResult, child) -> child.transform(prevResult, i18n, field, config, defaults, registry),
+                        (a, b) -> { throw new UnsupportedOperationException("Cannot transform GUIs in parallel!"); });
     }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/ComposedGuiRegistryAccess.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/ComposedGuiRegistryAccess.java
@@ -66,4 +66,14 @@ public class ComposedGuiRegistryAccess implements GuiRegistryAccess {
                         (prevResult, child) -> child.transform(prevResult, i18n, field, config, defaults, registry),
                         (a, b) -> { throw new UnsupportedOperationException("Cannot transform GUIs in parallel!"); });
     }
+    
+    @Override
+    public void runPreHook(String i18n, Field field, Object config, Object defaults, GuiRegistryAccess registry) {
+        children.forEach(child -> child.runPreHook(i18n, field, config, defaults, registry));
+    }
+    
+    @Override
+    public void runPostHook(List<AbstractConfigListEntry> guis, String i18n, Field field, Object config, Object defaults, GuiRegistryAccess registry) {
+        children.forEach(child -> child.runPostHook(guis, i18n, field, config, defaults, registry));
+    }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/DefaultGuiRegistryAccess.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/DefaultGuiRegistryAccess.java
@@ -51,4 +51,14 @@ public class DefaultGuiRegistryAccess implements GuiRegistryAccess {
     ) {
         return guis;
     }
+    
+    @Override
+    public void runPreHook(String i18n, Field field, Object config, Object defaults, GuiRegistryAccess registry) {
+        // No-op
+    }
+    
+    @Override
+    public void runPostHook(List<AbstractConfigListEntry> guis, String i18n, Field field, Object config, Object defaults, GuiRegistryAccess registry) {
+        // No-op
+    }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/GuiRegistry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/GuiRegistry.java
@@ -37,8 +37,8 @@ import java.util.stream.Stream;
 @Environment(EnvType.CLIENT)
 public final class GuiRegistry implements GuiRegistryAccess {
     
-    private Map<Priority, List<ProviderEntry>> providers = new HashMap<>();
-    private List<TransformerEntry> transformers = new ArrayList<>();
+    private final Map<Priority, List<ProviderEntry>> providers = new EnumMap<>(Priority.class);
+    private final List<TransformerEntry> transformers = new ArrayList<>();
     
     public GuiRegistry() {
         for (Priority priority : Priority.values()) {

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/GuiRegistry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/GuiRegistry.java
@@ -152,23 +152,6 @@ public final class GuiRegistry implements GuiRegistryAccess {
         LAST
     }
     
-    private static class ProviderEntry {
-        final Predicate<Field> predicate;
-        final GuiProvider provider;
-        
-        ProviderEntry(Predicate<Field> predicate, GuiProvider provider) {
-            this.predicate = predicate;
-            this.provider = provider;
-        }
-    }
-    
-    private static class TransformerEntry {
-        final Predicate<Field> predicate;
-        final GuiTransformer transformer;
-        
-        TransformerEntry(Predicate<Field> predicate, GuiTransformer transformer) {
-            this.predicate = predicate;
-            this.transformer = transformer;
-        }
-    }
+    private record ProviderEntry(Predicate<Field> predicate, GuiProvider provider) {}
+    private record TransformerEntry(Predicate<Field> predicate, GuiTransformer transformer) {}
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/registry/api/GuiRegistryHook.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/registry/api/GuiRegistryHook.java
@@ -25,35 +25,13 @@ import net.fabricmc.api.Environment;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.List;
 
+@FunctionalInterface
 @Environment(EnvType.CLIENT)
-public interface GuiRegistryAccess extends GuiProvider, GuiTransformer {
-    default List<AbstractConfigListEntry> getAndTransform(
-            String i18n,
-            Field field,
-            Object config,
-            Object defaults,
-            GuiRegistryAccess registry
-    ) {
-        runPreHook(i18n, field, config, defaults, registry);
-        List<AbstractConfigListEntry> guis = transform(get(i18n, field, config, defaults, registry), i18n, field, config, defaults, registry);
-        runPostHook(Collections.unmodifiableList(guis), i18n, field, config, defaults, registry);
-        return guis;
-    }
-    
-    @ApiStatus.Internal
-    void runPreHook(
-            String i18n,
-            Field field,
-            Object config,
-            Object defaults,
-            GuiRegistryAccess registry
-    );
-    
-    @ApiStatus.Internal
-    void runPostHook(
+@ApiStatus.Experimental
+public interface GuiRegistryHook {
+    void run(
             List<AbstractConfigListEntry> guis,
             String i18n,
             Field field,


### PR DESCRIPTION
## Overview

This PR adds the ability to register pre & post hooks with the `GuiRegistry`. Registered hooks are run before and after each `Field` is transformed into GUIs, allowing users to (for example) get a reference to the final GUIs.

## Motivation
A user could achieve a similar effect using a `GuiTransformer`, however there is a risk that another transformer may "pull the rug out" and remove/replace the GUI in question. Hooks solve this issue with an immutable GUI list and not using a return value. Therefore a post hook is guaranteed to run after all destructive changes have happened.

Without this PR, a user could register their own requirements using the transformer API, which will work for most cases.

With this PR, a user can register requirements without having to make any assumptions.

This PR also starts the ball rolling for a dedicated AutoConfig Requirements API using declarative annotations.

## Question

The above motivation hopefully justifies having a "post hook" API, however I've only included a "pre hook" for completeness.  
**Is there any reasom to include or not include a "pre hook"** in this PR? If not, should "post hook" be renamed?

## Related changes

This PR includes a number of small related changes to cleanup and modernize `GuiRegistry`'s internal implementation. Namely:

- [Use a record for provider/transformer entries](https://github.com/shedaniel/cloth-config/pull/215/commits/ea9999ee7dd0cb845e24e02edbda33764a0089e5)
- [Use EnumMap instead of HashMap](https://github.com/shedaniel/cloth-config/pull/215/commits/f1b0b15b6cd67c6af171a5db2efabb09e5ee776a)
- [Simplify GuiRegistry.get()](https://github.com/shedaniel/cloth-config/pull/215/commits/4098afcd8e3298fbd4d1a963263d9c5d10187ae6)
- [Simplify GuiRegistry.transform()](https://github.com/shedaniel/cloth-config/pull/215/commits/d833ff100ef266bb9a5d311ae1035cdc5a6329e3)

These changes could be dropped or moved to a different PR, however I felt it was simpler to include them here as they lay the foundation for this PR's core changes.

You may find it easier to review this PR one commit at a time.

A temporary "example" commit is also included, to aid in testing & reviewing. **This commit should be dropped before merging** (d789d6ca5f5c3fdff4f9526448ca1d18cc16150f).

<details><summary>Original description</summary>
<p>

Autoconfig requirement support will require operating with _finished_ Config Entry GUIs in order to _a)_ keep track of what GUIs have been created in a lookup table and _b)_ register GUIs that have dependencies declared with a `RequirementManager`.

This could be done internally by injecting additional code into `GuiRegistry` or by adding default `GuiTransformers`, however the former seems short-sighted and the latter isn't very robust, seeing as **there's no guarantee the `gui` list won't change** (or be entirely replaced) by another transformer running after us.

IMO the best solution is a "post" event hook. The handler can be passed an `Unmodifiable List`, ensuring that the GUI objects the handler sees are the same ones that will actually be used.

It seems silly to do this entirely internally, and strange to have a public "post" hook without a "pre" hook, so this PR follows the above to its logical conclusion and adds an experimental public API to register pre & post event hooks on `GuiRegistry`.

I wasn't sure whether or not it made sense for event hooks to be subject to predicates (in the same way that registered `GuiProvider` and `GuiTransformer`s are). This can be added easily if desired, but will increase the number of new experimental API methods on `GuiRegistry` a lot...

This PR is blocking Requirement support for autoconfig (as per #195 & #204).

</p>
</details> 