### PR TITLE
Autoconfig Requirement API discussion

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -23,10 +23,7 @@ import me.shedaniel.autoconfig.requirements.DefaultRequirements;
 import me.shedaniel.clothconfig2.api.DisableableWidget;
 import me.shedaniel.clothconfig2.api.HideableWidget;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 public class ConfigEntry {
     
@@ -163,37 +160,12 @@ public class ConfigEntry {
         private Requirements() {}
         
         /**
-         * Defines zero or more {@link Requirement} definitions that will control whether this Config Entry GUI is
-         * enabled or disabled.
-         * 
-         * @see Requirement
-         * @see DisableableWidget
-         */
-        @Retention(RetentionPolicy.RUNTIME)
-        @Target(ElementType.FIELD)
-        public @interface EnableIf {
-            Requirement[] value();
-            Quantifier quantifier() default Quantifier.ALL;
-        }
-        
-        /**
-         * Defines zero or more {@link Requirement} definitions that will control whether this Config Entry GUI is
-         * displayed on the screen.
+         * Defines a requirement that will control whether this Config Entry GUI is enabled or disabled.
          *
-         * @see Requirement
-         * @see HideableWidget
-         */
-        @Retention(RetentionPolicy.RUNTIME)
-        @Target(ElementType.FIELD)
-        public @interface DisplayIf {
-            Requirement[] value();
-            Quantifier quantifier() default Quantifier.ALL;
-        }
-        
-        /**
-         * Defines a Requirement, which is a reference to a method handler
-         * along with a set of arguments to be passed to the Handler.
-         * 
+         * <p>
+         *     The requirement either references a handler method or another Config Entry GUI.
+         * </p>
+         *
          * <p>
          *     If a handler method is referenced, it will be passed {@link #refArgs()} and {@link #staticArgs()}.
          * </p>
@@ -207,20 +179,24 @@ public class ConfigEntry {
          *     However if the referenced Config Entry has a <strong>boolean value</strong>, a default condition
          *     of {@code "true"} will be assumed.
          * </p>
+         *
+         * @see DisableableWidget
          */
         @Retention(RetentionPolicy.RUNTIME)
-        public @interface Requirement {
+        @Target(ElementType.FIELD)
+        @Repeatable(EnableIfGroup.class)
+        public @interface EnableIf {
             
             /**
              * A {@link Ref reference} to a Handler method or a Config Entry.
-             * 
+             *
              * @see DefaultRequirements
              */
             Ref value();
             
             /**
              * One or more conditions to be compared with the depended-on Config Entry's value.
-             * Will be parsed in the same way as {@link Requirement#staticArgs()}.
+             * Will be parsed in the same way as {@link #staticArgs()}.
              */
             String[] conditions() default {};
             
@@ -231,7 +207,7 @@ public class ConfigEntry {
             
             /**
              * Zero or more static values to be passed to the handler method.
-             * 
+             *
              * <p>The following parameter types are supported:
              * <ul>
              *     <li>{@link String}: The arg will be used as-is.
@@ -252,6 +228,43 @@ public class ConfigEntry {
         }
         
         /**
+         * Defines a requirement that will control whether this Config Entry GUI is displayed on the screen.
+         * 
+         * <p>
+         *     Otherwise identical to {@link EnableIf}
+         * </p>
+         *
+         * @see EnableIf
+         * @see HideableWidget
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        @Repeatable(DisplayIfGroup.class)
+        public @interface DisplayIf {
+            
+            /**
+             * @see EnableIf#value()
+             */
+            Ref value();
+            
+            /**
+             * @see EnableIf#conditions()
+             */
+            String[] conditions() default {};
+            
+            /**
+             * @see EnableIf#refArgs()
+             */
+            Ref[] refArgs() default {};
+            
+            /**
+             * @see EnableIf#staticArgs()
+             */
+            String[] staticArgs() default {};
+        }
+        
+        
+        /**
          * Can be applied to a handler method to declare a list of {@link Ref refs} that should be passed to the handler
          * as its initial arguments.
          */
@@ -259,6 +272,20 @@ public class ConfigEntry {
         @Target(ElementType.METHOD)
         public @interface ConstParams {
             Ref[] value();
+        }
+        
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        public @interface EnableIfGroup {
+            EnableIf[] value();
+            Quantifier quantifier() default Quantifier.ALL;
+        }
+        
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        public @interface DisplayIfGroup {
+            DisplayIf[] value();
+            Quantifier quantifier() default Quantifier.ALL;
         }
     }
     

--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -193,25 +193,41 @@ public class ConfigEntry {
         /**
          * Defines a Requirement, which is a reference to a method handler
          * along with a set of arguments to be passed to the Handler.
+         * 
+         * <p>
+         *     If a handler method is referenced, it will be passed {@link #refArgs()} and {@link #staticArgs()}.
+         * </p>
+         *
+         * <p>
+         *     If a Config Entry is referenced, its value will be compared against {@link #conditions()}.
+         * </p>
+         *
+         * <p>
+         *     If a Config Entry is referenced and {@link #conditions()} is empty, an exception will be thrown.
+         *     However if the referenced Config Entry has a <strong>boolean value</strong>, a default condition
+         *     of {@code "true"} will be assumed.
+         * </p>
          */
         @Retention(RetentionPolicy.RUNTIME)
         public @interface Requirement {
-            /**
-             * The name of the Handler method to be used.
-             */
-            String value();
             
             /**
-             * The class in which to look for the Handler method. Defaults to {@link DefaultRequirements}.
+             * A {@link Ref reference} to a Handler method or a Config Entry.
              * 
              * @see DefaultRequirements
              */
-            Class<?> cls() default DefaultRequirements.class;
+            Ref value();
             
             /**
-             * Zero or more {@link ConfigEntry.Ref references} to Config Entries, whose value should be passed to the handler method.
+             * One or more conditions to be compared with the depended-on Config Entry's value.
+             * Will be parsed in the same way as {@link Requirement#staticArgs()}.
              */
-            ConfigEntry.Ref[] refArgs() default {};
+            String[] conditions() default {};
+            
+            /**
+             * Zero or more {@link Ref references} to Config Entries, whose value should be passed to the handler method.
+             */
+            Ref[] refArgs() default {};
             
             /**
              * Zero or more static values to be passed to the handler method.
@@ -273,4 +289,6 @@ public class ConfigEntry {
     private static class None {
         private None() {}
     }
+    
+    private static final String FOO = "FOO";
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -19,6 +19,10 @@
 
 package me.shedaniel.autoconfig.annotation;
 
+import me.shedaniel.autoconfig.requirements.DefaultRequirements;
+import me.shedaniel.clothconfig2.api.DisableableWidget;
+import me.shedaniel.clothconfig2.api.HideableWidget;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -153,5 +157,120 @@ public class ConfigEntry {
                 BUTTON
             }
         }
+    }
+    
+    public static class Requirements {
+        private Requirements() {}
+        
+        /**
+         * Defines zero or more {@link Requirement} definitions that will control whether this Config Entry GUI is
+         * enabled or disabled.
+         * 
+         * @see Requirement
+         * @see DisableableWidget
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        public @interface EnableIf {
+            Requirement[] value();
+            Quantifier quantifier() default Quantifier.ALL;
+        }
+        
+        /**
+         * Defines zero or more {@link Requirement} definitions that will control whether this Config Entry GUI is
+         * displayed on the screen.
+         *
+         * @see Requirement
+         * @see HideableWidget
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        public @interface DisplayIf {
+            Requirement[] value();
+            Quantifier quantifier() default Quantifier.ALL;
+        }
+        
+        /**
+         * Defines a Requirement, which is a reference to a method handler
+         * along with a set of arguments to be passed to the Handler.
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        public @interface Requirement {
+            /**
+             * The name of the Handler method to be used.
+             */
+            String value();
+            
+            /**
+             * The class in which to look for the Handler method. Defaults to {@link DefaultRequirements}.
+             * 
+             * @see DefaultRequirements
+             */
+            Class<?> cls() default DefaultRequirements.class;
+            
+            /**
+             * Zero or more {@link ConfigEntry.Ref references} to Config Entries, whose value should be passed to the handler method.
+             */
+            ConfigEntry.Ref[] refArgs() default {};
+            
+            /**
+             * Zero or more static values to be passed to the handler method.
+             * 
+             * <p>The following parameter types are supported:
+             * <ul>
+             *     <li>{@link String}: The arg will be used as-is.
+             *     <li>{@link Character}: The first char of the arg will be used. The arg must be exactly 1 characters long.
+             *     <li>{@link Boolean}: The arg will be checked against the following values (case-insensitive):
+             *     <ul>
+             *         <li>{@code true} for: {@code "true"}, {@code "t"}, or {@code "1"}.
+             *         <li>{@code false} for: {@code "false"}, {@code "f"}, or {@code "0"}.
+             *     </ul>
+             *     <li>{@link Enum}: The arg will be compared against the {@link Enum#name() name values} of the expected Enum.
+             *         The value must be an exact match (case-sensitive).
+             *     <li>{@code short int long float double}: The arg will be parsed using the appropriate method,
+             *         such as {@link Integer#valueOf(String)}.
+             * </ul>
+             * <p>An exception will be thrown if a match is not found, parsing fails, or the expected type is not listed above.
+             */
+            String[] staticArgs() default {};
+        }
+        
+        /**
+         * Can be applied to a handler method to declare a list of {@link Ref refs} that should be passed to the handler
+         * as its initial arguments.
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.METHOD)
+        public @interface ConstParams {
+            Ref[] value();
+        }
+    }
+    
+    /**
+     * Defines a reference to a {@link ConfigEntry}.
+     *
+     * <p>{@code value} should be the name of the {@code ConfigEntry}'s defining field.
+     * <p>{@code cls} defines the class in which to look for the field.
+     * If {@code cls} is set to the default value ({@link None None.class}),
+     * then the annotated class is searched instead.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Ref {
+        String value();
+        Class<?> cls() default None.class;
+    }
+    
+    /**
+     * A quantifier representing how many things are required.
+     */
+    public enum Quantifier {
+        ALL, ANY, ONE, NONE
+    }
+    
+    /**
+     * Used by ConfigEntry annotations to indicate no class is set.
+     */
+    private static class None {
+        private None() {}
     }
 }

--- a/common/src/main/java/me/shedaniel/autoconfig/example/ExampleConfig.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/example/ExampleConfig.java
@@ -25,7 +25,6 @@ import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.EnumHandler.EnumDisplayOption;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Ref;
-import me.shedaniel.autoconfig.annotation.ConfigEntry.Requirements.Requirement;
 import me.shedaniel.autoconfig.requirements.DefaultRequirements;
 import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 import org.jetbrains.annotations.ApiStatus;
@@ -134,36 +133,27 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
             @ConfigEntry.BoundedDiscrete(min = -100, max = 100)
             public int intSlider = 50;
     
-            @ConfigEntry.Requirements.EnableIf(
-                    @Requirement(@Ref("coolToggle"))
-            )
+            @ConfigEntry.Requirements.EnableIf(@Ref("coolToggle"))
             public boolean dependsOnCoolToggle1 = false;
     
-            @ConfigEntry.Requirements.DisplayIf(
-                    @Requirement(@Ref("coolToggle"))
-            )
+            @ConfigEntry.Requirements.DisplayIf(@Ref("coolToggle"))
                     
             public boolean dependsOnCoolToggle2 = false;
     
-            @ConfigEntry.Requirements.EnableIf(@Requirement(
+            @ConfigEntry.Requirements.EnableIf(
                     value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.IS),
                     refArgs = { @Ref("coolToggle"), @Ref("lameToggle") }
-            ))
+            )
             public boolean dependsOnToggleMatch = false;
             
-            @ConfigEntry.Requirements.EnableIf(@Requirement(@Ref(cls = Handlers.class, value = "intSliderIsBigOrSmall")))
+            @ConfigEntry.Requirements.EnableIf(@Ref(cls = Handlers.class, value = "intSliderIsBigOrSmall"))
             public boolean dependsOnIntSlider = true;
     
             @ConfigEntry.Gui.TransitiveObject
+            @ConfigEntry.Requirements.EnableIf(@Ref("coolToggle"))
             @ConfigEntry.Requirements.EnableIf(
-                    value = {
-                            @Requirement(@Ref("coolToggle")),
-                            @Requirement(
-                                    value = @Ref("coolEnum"),
-                                    conditions = { "GOOD", "EXCELLENT" }
-                            )
-                    },
-                    quantifier = ConfigEntry.Quantifier.ALL
+                    value = @Ref("coolEnum"),
+                    conditions = { "GOOD", "EXCELLENT" }
             )
             public DependantObject dependantObject = new DependantObject();
             public static class DependantObject {
@@ -171,19 +161,15 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
                 public boolean toggle1 = false;
                 
                 @ConfigEntry.Requirements.EnableIf(
-                        @Requirement(
-                                value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.ANY_MATCH),
-                                refArgs = @Ref(cls = DependencySubCategory.class, value = "intSlider"),
-                                staticArgs = { "50", "100" }
-                        )
+                        value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.ANY_MATCH),
+                        refArgs = @Ref(cls = DependencySubCategory.class, value = "intSlider"),
+                        staticArgs = { "50", "100" }
                 )
                 public boolean toggle2 = true;
             }
     
             @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
-            @ConfigEntry.Requirements.EnableIf(
-                    @Requirement(@Ref("coolToggle"))
-            )
+            @ConfigEntry.Requirements.EnableIf(@Ref("coolToggle"))
             public DependantCollapsible dependantCollapsible = new DependantCollapsible();
             public static class DependantCollapsible {
                 public boolean toggle1 = false;
@@ -191,14 +177,14 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
             }
     
             @ConfigEntry.Requirements.EnableIf(
-                    @Requirement(@Ref(cls = DependencySubCategory.class, value = "coolToggle"))
+                    @Ref(cls = DependencySubCategory.class, value = "coolToggle")
             )
             public List<Integer> list = Arrays.asList(1, 2, 3);
     
         }
     
         @ConfigEntry.Requirements.EnableIf(
-                @Requirement(@Ref(cls = DependencySubCategory.class, value = "coolToggle"))
+                @Ref(cls = DependencySubCategory.class, value = "coolToggle")
         )
         public boolean dependsOnCoolToggleOutside = false;
         

--- a/common/src/main/java/me/shedaniel/autoconfig/example/ExampleConfig.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/example/ExampleConfig.java
@@ -24,6 +24,8 @@ import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.EnumHandler.EnumDisplayOption;
+import me.shedaniel.autoconfig.annotation.ConfigEntry.Ref;
+import me.shedaniel.autoconfig.annotation.ConfigEntry.Requirements.Requirement;
 import me.shedaniel.autoconfig.requirements.DefaultRequirements;
 import me.shedaniel.autoconfig.serializer.PartitioningSerializer;
 import org.jetbrains.annotations.ApiStatus;
@@ -108,34 +110,11 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
     public static class ModuleC implements ConfigData {
         
         public static class Handlers {
-            
             @ConfigEntry.Requirements.ConstParams(
-                    @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle")
+                    @Ref(cls = DependencySubCategory.class, value = "intSlider")
             )
-            private static boolean coolToggleIsEnabled(boolean coolToggle) {
-                return coolToggle;
-            }
-            
-            @ConfigEntry.Requirements.ConstParams({
-                    @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle"),
-                    @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "lameToggle")
-            })
-            private static Boolean coolToggleMatchesLameToggle(boolean coolToggle, Boolean lameToggle) {
-                return coolToggle == lameToggle;
-            }
-            
-            @ConfigEntry.Requirements.ConstParams(
-                    @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "intSlider")
-            )
-            private static boolean intSliderIsBigOrSmall(int intSlider) {
-                return intSlider > 70 || intSlider < -70;
-            }
-            
-            @ConfigEntry.Requirements.ConstParams(
-                    @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolEnum")
-            )
-            private static boolean coolEnumIsGoodOrBetter(DependencyDemoEnum coolEnum) {
-                return coolEnum == DependencyDemoEnum.GOOD || coolEnum == DependencyDemoEnum.EXCELLENT;
+            private static boolean intSliderIsBigOrSmall(int value) {
+                return value > 70 || value < -70;
             }
         }
         
@@ -155,42 +134,33 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
             @ConfigEntry.BoundedDiscrete(min = -100, max = 100)
             public int intSlider = 50;
     
-            @ConfigEntry.Requirements.EnableIf(@ConfigEntry.Requirements.Requirement(
-                    value = "isTrue",
-                    refArgs = @ConfigEntry.Ref("coolToggle")
-            ))
+            @ConfigEntry.Requirements.EnableIf(
+                    @Requirement(@Ref("coolToggle"))
+            )
             public boolean dependsOnCoolToggle1 = false;
     
-            @ConfigEntry.Requirements.DisplayIf(@ConfigEntry.Requirements.Requirement(
-                    value = "coolToggleIsEnabled",
-                    cls = Handlers.class
-            ))
+            @ConfigEntry.Requirements.DisplayIf(
+                    @Requirement(@Ref("coolToggle"))
+            )
                     
             public boolean dependsOnCoolToggle2 = false;
     
-            @ConfigEntry.Requirements.EnableIf(@ConfigEntry.Requirements.Requirement(
-                    value = DefaultRequirements.IS,
-                    refArgs = {
-                            @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle"),
-                            @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "lameToggle")
-                    }
+            @ConfigEntry.Requirements.EnableIf(@Requirement(
+                    value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.IS),
+                    refArgs = { @Ref("coolToggle"), @Ref("lameToggle") }
             ))
             public boolean dependsOnToggleMatch = false;
             
-            @ConfigEntry.Requirements.EnableIf(@ConfigEntry.Requirements.Requirement(cls = Handlers.class, value = "intSliderIsBigOrSmall"))
+            @ConfigEntry.Requirements.EnableIf(@Requirement(@Ref(cls = Handlers.class, value = "intSliderIsBigOrSmall")))
             public boolean dependsOnIntSlider = true;
     
             @ConfigEntry.Gui.TransitiveObject
             @ConfigEntry.Requirements.EnableIf(
                     value = {
-                            @ConfigEntry.Requirements.Requirement(
-                                    value = DefaultRequirements.TRUE,
-                                    refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle")
-                            ),
-                            @ConfigEntry.Requirements.Requirement(
-                                    value = DefaultRequirements.ANY_MATCH,
-                                    refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolEnum"),
-                                    staticArgs = { "GOOD", "EXCELLENT" }
+                            @Requirement(@Ref("coolToggle")),
+                            @Requirement(
+                                    value = @Ref("coolEnum"),
+                                    conditions = { "GOOD", "EXCELLENT" }
                             )
                     },
                     quantifier = ConfigEntry.Quantifier.ALL
@@ -201,9 +171,9 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
                 public boolean toggle1 = false;
                 
                 @ConfigEntry.Requirements.EnableIf(
-                        @ConfigEntry.Requirements.Requirement(
-                                value = DefaultRequirements.ANY_MATCH,
-                                refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "intSlider"),
+                        @Requirement(
+                                value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.ANY_MATCH),
+                                refArgs = @Ref(cls = DependencySubCategory.class, value = "intSlider"),
                                 staticArgs = { "50", "100" }
                         )
                 )
@@ -212,10 +182,7 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
     
             @ConfigEntry.Gui.CollapsibleObject(startExpanded = true)
             @ConfigEntry.Requirements.EnableIf(
-                    @ConfigEntry.Requirements.Requirement(
-                            value = DefaultRequirements.TRUE,
-                            refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle")
-                    )
+                    @Requirement(@Ref("coolToggle"))
             )
             public DependantCollapsible dependantCollapsible = new DependantCollapsible();
             public static class DependantCollapsible {
@@ -224,20 +191,14 @@ public class ExampleConfig extends PartitioningSerializer.GlobalData {
             }
     
             @ConfigEntry.Requirements.EnableIf(
-                    @ConfigEntry.Requirements.Requirement(
-                            value = DefaultRequirements.TRUE,
-                            refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle")
-                    )
+                    @Requirement(@Ref(cls = DependencySubCategory.class, value = "coolToggle"))
             )
             public List<Integer> list = Arrays.asList(1, 2, 3);
     
         }
     
         @ConfigEntry.Requirements.EnableIf(
-                @ConfigEntry.Requirements.Requirement(
-                        value = DefaultRequirements.TRUE,
-                        refArgs = @ConfigEntry.Ref(cls = DependencySubCategory.class, value = "coolToggle")
-                )
+                @Requirement(@Ref(cls = DependencySubCategory.class, value = "coolToggle"))
         )
         public boolean dependsOnCoolToggleOutside = false;
         

--- a/common/src/main/java/me/shedaniel/autoconfig/requirements/DefaultRequirements.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/requirements/DefaultRequirements.java
@@ -1,0 +1,63 @@
+package me.shedaniel.autoconfig.requirements;
+
+import java.util.Objects;
+
+public class DefaultRequirements {
+    private DefaultRequirements() {}
+    
+    /**
+     * The condition is met when the argument is {@code true}.
+     * 
+     * @see #isTrue(Boolean) 
+     */
+    public static final String TRUE = "isTrue";
+    
+    /**
+     * The condition is met when the argument is {@code false}.
+     * 
+     * @see #isFalse(Boolean) 
+     */
+    public static final String FALSE = "isFalse";
+    
+    /**
+     * The condition is met when the first argument is equal to the second.
+     * 
+     * @see #is(Object, Object) 
+     */
+    public static final String IS = "is";
+    
+    /**
+     * The condition is met when at least one {@code arg} is equal to another.
+     * 
+     * @see #anyMatch(Object[]) 
+     */
+    public static final String ANY_MATCH = "anyMatch";
+    
+    private static boolean isTrue(Boolean value) {
+        return Boolean.TRUE.equals(value);
+    }
+    
+    private static boolean isFalse(Boolean value) {
+        return Boolean.FALSE.equals(value);
+    }
+    
+    private static <T> boolean is(T value, T condition) {
+        return Objects.equals(value, condition);
+    }
+    
+    private static <T> boolean anyMatch(T ...args) {
+        for (int i = 0; i < args.length; i++) {
+            for (int j = 0; j < i; j++) {
+                if (Objects.equals(args[i], args[j])) {
+                    return true;
+                }
+            }
+            for (int j = i+1; j < args.length; j++) {
+                if (Objects.equals(args[i], args[j])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
I'm opening this Draft PR hoping to get some feedback and spark discussion on the user-facing annotation API, hopefully before I spend too much time implementing the backend for it...

Each commit takes a slightly different approach. I also have some other examples in some different branches (see below)...

### 1

The [first commit](https://github.com/shedaniel/cloth-config/commit/d3700954f200baee22499c1006b53dd907c9ea6d) takes a simplistic approach.

All requirement annotations must reference a handler method and optionally provide arguments to it.
Additionally, `DefaultRequirements` handlers are provided to prevent users needing to re-implement common requirement handlers such as simple equality checks.

This can lead to somewhat clunky annotation declarations to do fairly simple requirements:

```java
// Enabled when coolToogle is `true`
@ConfigEntry.Requirements.EnableIf(
        @Requirement(
                value = @Ref(cls = DefaultRequirements.class, value = DefaultRequirements.TRUE),
                refArgs = @Ref("coolToggle")
        )
)
```

### 2

The [second commit](https://github.com/shedaniel/cloth-config/commit/cca4a0fa8b4e0df3e8d32d3f6e7a057d9012216e) attempts to improve the UX by introducing a concept of "simple" requirements. These are requirements that reference a Config Entry GUI instead of an actual handler method.

Simple requirements would be _built into_ actual requirements during dependency setup. We would need to follow the requirement reference looking for a method handler, and then try again looking for a config entry field if no method exists.

```java
// Same example as above
@ConfigEntry.Requirements.EnableIf(
        @Requirement(@Ref("coolToggle"))
)
```

### 3

The [third commit](https://github.com/shedaniel/cloth-config/commit/601983132803d03701464bcf352110c74a9d1b45) removes the separate `@Requirement` annotation that was used by both `@EnableIf` and `@DisplayIf` and instead moves all of its parameters into each of those.

This is a bit of a painful compromise since it leads to having to maintain the same interface in two places, however it significantly improves the user experience by reducing boilerplate from dependency annotations.

In my opinion it's well worth it:

```java
// Same again
@ConfigEntry.Requirements.EnableIf(@Ref("coolToggle"))
```

### Other work

Other examples are in the [original draft PR](https://github.com/shedaniel/cloth-config/pull/195/files#diff-2af5c9f813c0a8b3faf62e9fd229af7d2a389b934b817bf66af5a827578402e8) and my newer [autoconfig dependencies branch](https://github.com/shedaniel/cloth-config/compare/v8...MattSturgeon:cloth-config:autoconfig-dependencies#diff-2af5c9f813c0a8b3faf62e9fd229af7d2a389b934b817bf66af5a827578402e8)