### PR TITLE
Bump SnakeYAML from 1.27 to 2.2 to address multiple security vulnerabilities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ maven_group=me.shedaniel.cloth
 
 jankson_version=1.2.0
 toml4j_version=0.7.2
-snakeyaml_version=1.27
+snakeyaml_version=2.2
 
 fabric_loader_version=0.15.11
 fabric_api_version=0.100.1+1.21


### PR DESCRIPTION
The currently used SnakeYAML v1.27 has multiple security vulnerabilities. Specifically:
CVE-2022-1471
CVE-2022-25857
CVE-2022-41854
CVE-2022-38750
CVE-2022-38751
CVE-2022-38749
CVE-2022-38752

This PR updates SnakeYAML to v2.2, which is currently the latest version. Alternatively, updating to v2.0 or v2.1 would also resolve all of the vulnerabilities.

I did not find any compatibility issues with the update, but I'm also not that familiar with SnakeYAML or with your codebase, so I might have missed something. Apologies if applying this update is not feasible.