### PR TITLE
Improved lists with DropdownBox support

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/api/ConfigEntryBuilder.java
@@ -31,8 +31,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
 
 import java.util.List;
 import java.util.function.Function;
@@ -154,5 +158,31 @@ public interface ConfigEntryBuilder {
     
     default DropdownMenuBuilder<String> startStringDropdownMenu(Component fieldNameKey, String value, Function<String, Component> toTextFunction) {
         return startDropdownMenu(fieldNameKey, TopCellElementBuilder.of(value, s -> s, toTextFunction), new DefaultSelectionCellCreator<>());
+    }
+    
+    <T> DropdownListBuilder<T> startDropdownList(Component fieldNameKey, List<T> value, Function<T, SelectionTopCellElement<T>> topCellCreator, SelectionCellCreator<T> cellCreator);
+    
+    default DropdownListBuilder<ResourceLocation> startItemIdentifierList(Component fieldNameKey, List<ResourceLocation> value) {
+    	DropdownListBuilder<ResourceLocation> entry = startDropdownList(fieldNameKey, value, element -> DropdownMenuBuilder.TopCellElementBuilder.ofItemIdentifier(BuiltInRegistries.ITEM.get(element)), DropdownMenuBuilder.CellCreatorBuilder.ofItemIdentifier());
+    	entry.setSelections(BuiltInRegistries.ITEM.keySet());
+    	return entry;
+    }
+    
+    default DropdownListBuilder<ResourceLocation> startBlockIdentifierList(Component fieldNameKey, List<ResourceLocation> value) {
+    	DropdownListBuilder<ResourceLocation> entry = startDropdownList(fieldNameKey, value, element -> DropdownMenuBuilder.TopCellElementBuilder.ofBlockIdentifier(BuiltInRegistries.BLOCK.get(element)), DropdownMenuBuilder.CellCreatorBuilder.ofBlockIdentifier());
+    	entry.setSelections(BuiltInRegistries.BLOCK.keySet());
+    	return entry;
+    }
+    
+    default DropdownListBuilder<Item> startItemObjectList(Component fieldNameKey, List<Item> value) {
+    	DropdownListBuilder<Item> entry = startDropdownList(fieldNameKey, value, element -> DropdownMenuBuilder.TopCellElementBuilder.ofItemObject(element), DropdownMenuBuilder.CellCreatorBuilder.ofItemObject());
+    	entry.setSelections(BuiltInRegistries.ITEM);
+    	return entry;
+    }
+    
+    default DropdownListBuilder<Block> startBlockObjectList(Component fieldNameKey, List<Block> value) {
+    	DropdownListBuilder<Block> entry = startDropdownList(fieldNameKey, value, element -> DropdownMenuBuilder.TopCellElementBuilder.ofBlockObject(element), DropdownMenuBuilder.CellCreatorBuilder.ofBlockObject());
+    	entry.setSelections(BuiltInRegistries.BLOCK);
+    	return entry;
     }
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListCell.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListCell.java
@@ -53,6 +53,12 @@ public abstract class BaseListCell extends AbstractContainerEventHandler impleme
     
     public abstract void render(GuiGraphics graphics, int index, int y, int x, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isSelected, float delta);
     
+    public void lateRender(GuiGraphics graphics, int mouseX, int mouseY, float delta) {}
+    
+    public int getMorePossibleHeight() {
+    	return 0;
+    }
+    
     public void updateSelected(boolean isSelected) {}
     
     public boolean isRequiresRestart() {

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -311,6 +311,21 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     }
     
     @Override
+    public void lateRender(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        super.lateRender(graphics, mouseX, mouseY, delta);
+        BaseListCell focused = !isExpanded() || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+        if(focused != null) {
+        	focused.lateRender(graphics, mouseX, mouseY, delta);
+        }
+    }
+    
+    @Override
+    public int getMorePossibleHeight() { 
+    	BaseListCell focused = !isExpanded() || getFocused() == null || !(getFocused() instanceof BaseListCell) ? null : (BaseListCell) getFocused();
+    	return focused != null ? focused.getMorePossibleHeight() : 0;
+    }
+    
+    @Override
     public void updateSelected(boolean isSelected) {
         for (C cell : cells) {
             cell.updateSelected(isSelected && getFocused() == cell && isExpanded());

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
@@ -76,7 +76,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         this.resetButton = Button.builder(resetButtonKey, widget -> {
             selectionElement.topRenderer.setValue(defaultValue.get());
         }).bounds(0, 0, Minecraft.getInstance().font.width(resetButtonKey) + 6, 20).build();
-        this.selectionElement = new SelectionElement<>(this, new Rectangle(0, 0, 150, 20), new DefaultDropdownMenuElement<>(selections == null ? ImmutableList.of() : ImmutableList.copyOf(selections)), topRenderer, cellCreator);
+        this.selectionElement = new SelectionElement<>(this, new Rectangle(0, 0, fieldName.getString().isBlank() ? 300 : 150, 20), new DefaultDropdownMenuElement<>(selections == null ? ImmutableList.of() : ImmutableList.copyOf(selections)), topRenderer, cellCreator);
     }
     
     @Override
@@ -88,6 +88,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         this.selectionElement.active = isEditable();
         this.selectionElement.bounds.y = y;
         Component displayedFieldName = getDisplayedFieldName();
+        boolean hasName = !displayedFieldName.getString().isBlank();
         if (Minecraft.getInstance().font.isBidirectional()) {
             graphics.drawString(Minecraft.getInstance().font, displayedFieldName.getVisualOrderText(), window.getGuiScaledWidth() - x - Minecraft.getInstance().font.width(displayedFieldName), y + 6, getPreferredTextColor());
             this.resetButton.setX(x);
@@ -95,9 +96,9 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         } else {
             graphics.drawString(Minecraft.getInstance().font, displayedFieldName.getVisualOrderText(), x, y + 6, getPreferredTextColor());
             this.resetButton.setX(x + entryWidth - resetButton.getWidth());
-            this.selectionElement.bounds.x = x + entryWidth - 150 + 1;
+            this.selectionElement.bounds.x = x + (hasName ? entryWidth - 150 : 0) + 1;
         }
-        this.selectionElement.bounds.width = 150 - resetButton.getWidth() - 4;
+        this.selectionElement.bounds.width = (hasName ? 150 : entryWidth) - resetButton.getWidth() - 4;
         resetButton.render(graphics, mouseX, mouseY, delta);
         selectionElement.render(graphics, mouseX, mouseY, delta);
     }
@@ -251,6 +252,10 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         @NotNull
         public SelectionCellCreator<R> getCellCreator() {
             return cellCreator;
+        }
+        
+        public int getCellWidth() {
+        	return getCellCreator().getCellWidth() > 0 ? getCellCreator().getCellWidth() : getEntry().selectionElement.bounds.width;
         }
         
         @NotNull
@@ -408,18 +413,19 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         @Override
         public void lateRender(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
             int last10Height = getHeight();
-            int cWidth = getCellCreator().getCellWidth();
-            graphics.fill(lastRectangle.x, lastRectangle.y + lastRectangle.height, lastRectangle.x + cWidth, lastRectangle.y + lastRectangle.height + last10Height + 1, isExpanded() ? -1 : -6250336);
-            graphics.fill(lastRectangle.x + 1, lastRectangle.y + lastRectangle.height + 1, lastRectangle.x + cWidth - 1, lastRectangle.y + lastRectangle.height + last10Height, -16777216);
+            int cWidth = getCellWidth();
             graphics.pose().pushPose();
+            graphics.pose().translate(0, 0, 300f);
+            graphics.fill(lastRectangle.x, lastRectangle.y + lastRectangle.height, lastRectangle.x + cWidth, lastRectangle.y + lastRectangle.height + last10Height + 1, isExpanded() ? 0xFFFFFFFF : -6250336);
+            graphics.fill(lastRectangle.x + 1, lastRectangle.y + lastRectangle.height + 1, lastRectangle.x + cWidth - 1, lastRectangle.y + lastRectangle.height + last10Height, 0xFF000000);
             graphics.pose().translate(0, 0, 300f);
             
             ScissorsHandler.INSTANCE.scissor(new Rectangle(lastRectangle.x, lastRectangle.y + lastRectangle.height + 1, cWidth - 6, last10Height - 1));
             double yy = lastRectangle.y + lastRectangle.height - scroll;
             for (SelectionCellElement<R> cell : currentElements) {
                 if (yy + getCellCreator().getCellHeight() >= lastRectangle.y + lastRectangle.height && yy <= lastRectangle.y + lastRectangle.height + last10Height + 1) {
-                    graphics.fill(lastRectangle.x + 1, (int) yy, lastRectangle.x + getCellCreator().getCellWidth(), (int) yy + getCellCreator().getCellHeight(), 0xFF000000);
-                    cell.render(graphics, mouseX, mouseY, lastRectangle.x, (int) yy, getMaxScrollPosition() > 6 ? getCellCreator().getCellWidth() - 6 : getCellCreator().getCellWidth(), getCellCreator().getCellHeight(), delta);
+                    graphics.fill(lastRectangle.x + 1, (int) yy, lastRectangle.x + cWidth, (int) yy + getCellCreator().getCellHeight(), 0xFF000000);
+                    cell.render(graphics, mouseX, mouseY, lastRectangle.x, (int) yy, getMaxScrollPosition() > 6 ? cWidth - 6 : cWidth, getCellCreator().getCellHeight(), delta);
                 } else
                     cell.dontRender(graphics, delta);
                 yy += getCellCreator().getCellHeight();
@@ -429,12 +435,12 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             if (currentElements.isEmpty()) {
                 Font textRenderer = Minecraft.getInstance().font;
                 Component text = Component.translatable("text.cloth-config.dropdown.value.unknown");
-                graphics.drawString(textRenderer, text.getVisualOrderText(), (int) (lastRectangle.x + getCellCreator().getCellWidth() / 2f - textRenderer.width(text) / 2f), lastRectangle.y + lastRectangle.height + 3, -1);
+                graphics.drawString(textRenderer, text.getVisualOrderText(), (int) (lastRectangle.x + cWidth / 2f - textRenderer.width(text) / 2f), lastRectangle.y + lastRectangle.height + 3, -1);
             }
             
             if (getMaxScrollPosition() > 6) {
                 RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
-                int scrollbarPositionMinX = lastRectangle.x + getCellCreator().getCellWidth() - 6;
+                int scrollbarPositionMinX = lastRectangle.x + cWidth - 6;
                 int scrollbarPositionMaxX = scrollbarPositionMinX + 6;
                 int height = (int) (((last10Height) * (last10Height)) / this.getMaxScrollPosition());
                 height = Mth.clamp(height, 32, last10Height - 8);
@@ -470,7 +476,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         
         @Override
         public boolean isMouseOver(double mouseX, double mouseY) {
-            return isExpanded() && mouseX >= lastRectangle.x && mouseX <= lastRectangle.x + getCellCreator().getCellWidth() && mouseY >= lastRectangle.y + lastRectangle.height && mouseY <= lastRectangle.y + lastRectangle.height + getHeight() + 1;
+            return isExpanded() && mouseX >= lastRectangle.x && mouseX <= lastRectangle.x + getCellWidth() && mouseY >= lastRectangle.y + lastRectangle.height && mouseY <= lastRectangle.y + lastRectangle.height + getHeight() + 1;
         }
         
         @Override
@@ -505,7 +511,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         }
         
         protected void updateScrollingState(double double_1, double double_2, int int_1) {
-            this.scrolling = isExpanded() && lastRectangle != null && int_1 == 0 && double_1 >= (double) lastRectangle.x + getCellCreator().getCellWidth() - 6 && double_1 < (double) (lastRectangle.x + getCellCreator().getCellWidth());
+            this.scrolling = isExpanded() && lastRectangle != null && int_1 == 0 && double_1 >= (double) lastRectangle.x + getCellWidth() - 6 && double_1 < (double) (lastRectangle.x + getCellWidth());
         }
         
         @Override
@@ -548,7 +554,7 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         public abstract int getDropBoxMaxHeight();
         
         public int getCellWidth() {
-            return 132;
+            return -1;
         }
     }
     

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
@@ -58,7 +58,7 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
         this.object = object;
         this.entries = entries;
         this.expanded = defaultExpanded;
-        this.widget = new MultiElementListEntry<T>.CategoryLabelWidget();
+        this.widget = new MultiElementListEntry.CategoryLabelWidget();
         this.children = Lists.newArrayList(widget);
         this.children.addAll(entries);
         this.setReferenceProviderEntries((List) entries);

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/NestedListListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/NestedListListEntry.java
@@ -113,6 +113,18 @@ public final class NestedListListEntry<T, INNER extends AbstractConfigListEntry<
         }
         
         @Override
+        public void lateRender(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+        	nestedEntry.setParent((DynamicEntryListWidget) listListEntry.getParent());
+            nestedEntry.setScreen(listListEntry.getConfigScreen());
+            nestedEntry.lateRender(graphics, mouseX, mouseY, delta);
+        }
+        
+        @Override
+        public int getMorePossibleHeight() {
+        	return nestedEntry.getMorePossibleHeight();
+        }
+        
+        @Override
         public List<? extends GuiEventListener> children() {
             return Collections.singletonList(nestedEntry);
         }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/ConfigEntryBuilderImpl.java
@@ -31,6 +31,7 @@ import net.minecraft.network.chat.Component;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 @Environment(EnvType.CLIENT)
 public class ConfigEntryBuilderImpl implements ConfigEntryBuilder {
@@ -176,4 +177,8 @@ public class ConfigEntryBuilderImpl implements ConfigEntryBuilder {
         return new DropdownMenuBuilder<>(resetButtonKey, fieldNameKey, topCellElement, cellCreator);
     }
     
+    @Override
+    public <T> DropdownListBuilder<T> startDropdownList(Component fieldNameKey, List<T> value, Function<T, SelectionTopCellElement<T>> topCellCreator, SelectionCellCreator<T> cellCreator) {
+        return new DropdownListBuilder<>(resetButtonKey, fieldNameKey, value, topCellCreator, cellCreator);
+    }
 }

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownListBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownListBuilder.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Cloth Config.
+ * Copyright (C) 2020 - 2021 shedaniel
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package me.shedaniel.clothconfig2.impl.builders;
+
+import me.shedaniel.clothconfig2.gui.entries.DropdownBoxEntry;
+import me.shedaniel.clothconfig2.gui.entries.DropdownBoxEntry.SelectionCellCreator;
+import me.shedaniel.clothconfig2.gui.entries.DropdownBoxEntry.SelectionTopCellElement;
+import me.shedaniel.clothconfig2.gui.entries.NestedListListEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Environment(EnvType.CLIENT)
+public class DropdownListBuilder<T> extends FieldBuilder<List<T>, NestedListListEntry<T, DropdownBoxEntry<T>>, DropdownListBuilder<T>> {
+	protected List<T> value;
+	protected Supplier<T> defaultEntryValue = null;
+    protected Function<T, SelectionTopCellElement<T>> topCellCreator;
+    protected SelectionCellCreator<T> cellCreator;
+    protected Supplier<Optional<Component[]>> tooltipSupplier = () -> Optional.empty();
+    protected Consumer<List<T>> saveConsumer = null;
+    protected Iterable<T> selections = Collections.emptyList();
+    protected boolean suggestionMode = true;
+    
+    public DropdownListBuilder(Component resetButtonKey, Component fieldNameKey, List<T> value, Function<T, SelectionTopCellElement<T>> topCellCreator, SelectionCellCreator<T> cellCreator) {
+        super(resetButtonKey, fieldNameKey);
+        this.value = value;
+        this.topCellCreator = Objects.requireNonNull(topCellCreator);
+        this.cellCreator = Objects.requireNonNull(cellCreator);
+    }
+    
+    public DropdownListBuilder<T> setSelections(Iterable<T> selections) {
+        this.selections = selections;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setDefaultValue(Supplier<List<T>> defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setDefaultValue(List<T> defaultValue) {
+        this.defaultValue = () -> Objects.requireNonNull(defaultValue);
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setDefaultEntryValue(Supplier<T> defaultEntryValue) {
+        this.defaultEntryValue = defaultEntryValue;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setDefaultEntryValue(T defaultEntryValue) {
+        this.defaultEntryValue = () -> Objects.requireNonNull(defaultEntryValue);
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setSaveConsumer(Consumer<List<T>> saveConsumer) {
+        this.saveConsumer = saveConsumer;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setTooltipSupplier(Supplier<Optional<Component[]>> tooltipSupplier) {
+        this.tooltipSupplier = tooltipSupplier;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setTooltip(Optional<Component[]> tooltip) {
+        this.tooltipSupplier = () -> tooltip;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setTooltip(Component... tooltip) {
+        this.tooltipSupplier = () -> Optional.ofNullable(tooltip);
+        return this;
+    }
+    
+    public DropdownListBuilder<T> requireRestart() {
+        requireRestart(true);
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setErrorSupplier(Function<List<T>, Optional<Component>> errorSupplier) {
+        this.errorSupplier = errorSupplier;
+        return this;
+    }
+    
+    public DropdownListBuilder<T> setSuggestionMode(boolean suggestionMode) {
+        this.suggestionMode = suggestionMode;
+        return this;
+    }
+    
+    public boolean isSuggestionMode() {
+        return suggestionMode;
+    }
+    
+    @NotNull
+    @Override
+    public NestedListListEntry<T, DropdownBoxEntry<T>> build() {
+    	NestedListListEntry<T, DropdownBoxEntry<T>> listEntry = new NestedListListEntry<T, DropdownBoxEntry<T>>(
+    			getFieldNameKey(),
+    			value,
+				false,
+				tooltipSupplier,
+				saveConsumer,
+				defaultValue,
+				getResetButtonKey(),
+				true,
+				false,
+				(entryValue, list) -> {
+					Supplier<T> defaultValue = () -> entryValue;
+					if(entryValue == null) defaultValue = defaultEntryValue;
+					DropdownBoxEntry<T> entry = new DropdownBoxEntry<T>(CommonComponents.EMPTY, getResetButtonKey(), null, isRequireRestart(), defaultValue, null, selections, topCellCreator.apply(entryValue), cellCreator);
+			        entry.setSuggestionMode(suggestionMode);
+			        return entry;
+				});
+        if (errorSupplier != null)
+        	listEntry.setErrorSupplier(() -> errorSupplier.apply(listEntry.getValue()));
+    	
+        
+        return finishBuilding(listEntry);
+    }
+}

--- a/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/impl/builders/DropdownMenuBuilder.java
@@ -361,11 +361,11 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>,
         }
         
         public static SelectionCellCreator<ResourceLocation> ofItemIdentifier() {
-            return ofItemIdentifier(20, 146, 7);
+            return ofItemIdentifier(20, -1, 7);
         }
         
         public static SelectionCellCreator<ResourceLocation> ofItemIdentifier(int maxItems) {
-            return ofItemIdentifier(20, 146, maxItems);
+            return ofItemIdentifier(20, -1, maxItems);
         }
         
         public static SelectionCellCreator<ResourceLocation> ofItemIdentifier(int cellHeight, int cellWidth, int maxItems) {
@@ -410,11 +410,11 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>,
         
         
         public static SelectionCellCreator<ResourceLocation> ofBlockIdentifier() {
-            return ofBlockIdentifier(20, 146, 7);
+            return ofBlockIdentifier(20, -1, 7);
         }
         
         public static SelectionCellCreator<ResourceLocation> ofBlockIdentifier(int maxItems) {
-            return ofBlockIdentifier(20, 146, maxItems);
+            return ofBlockIdentifier(20, -1, maxItems);
         }
         
         public static SelectionCellCreator<ResourceLocation> ofBlockIdentifier(int cellHeight, int cellWidth, int maxItems) {
@@ -458,11 +458,11 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>,
         }
         
         public static SelectionCellCreator<Item> ofItemObject() {
-            return ofItemObject(20, 146, 7);
+            return ofItemObject(20, -1, 7);
         }
         
         public static SelectionCellCreator<Item> ofItemObject(int maxItems) {
-            return ofItemObject(20, 146, maxItems);
+            return ofItemObject(20, -1, maxItems);
         }
         
         public static SelectionCellCreator<Item> ofItemObject(int cellHeight, int cellWidth, int maxItems) {
@@ -506,11 +506,11 @@ public class DropdownMenuBuilder<T> extends FieldBuilder<T, DropdownBoxEntry<T>,
         }
         
         public static SelectionCellCreator<Block> ofBlockObject() {
-            return ofBlockObject(20, 146, 7);
+            return ofBlockObject(20, -1, 7);
         }
         
         public static SelectionCellCreator<Block> ofBlockObject(int maxItems) {
-            return ofBlockObject(20, 146, maxItems);
+            return ofBlockObject(20, -1, maxItems);
         }
         
         public static SelectionCellCreator<Block> ofBlockObject(int cellHeight, int cellWidth, int maxItems) {


### PR DESCRIPTION
Updated Pull Request from  #228 

Provides default builder methods to easily create Block or Item list config options.
Makes minimal adjustments to make DropdownBoxEntry work correctly inside NestedListListEntry and fix other issues related to DropdownBoxEntry.

Example:
![image](https://github.com/shedaniel/cloth-config/assets/2954947/1cb885ec-ee9e-42c2-ae66-885640b38a44)
results in:
![image](https://github.com/shedaniel/cloth-config/assets/2954947/412fa6ad-7cec-4e3c-9b01-ee76deba28c6)

Should close #184
Also fixes #224, #105 and #112