### PR TITLE
Make "Value:" and "Search..." translatable

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
@@ -49,7 +49,7 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
     protected final long orginial;
     private int minimum, maximum;
     private final Supplier<Integer> defaultValue;
-    private Function<Integer, Component> textGetter = integer -> Component.translatable("text.cloth-config.value", value);
+    private Function<Integer, Component> textGetter = integer -> Component.translatable("text.cloth-config.value", integer);
     private final List<AbstractWidget> widgets;
     
     @ApiStatus.Internal

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
@@ -49,7 +49,7 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
     protected final long orginial;
     private int minimum, maximum;
     private final Supplier<Integer> defaultValue;
-    private Function<Integer, Component> textGetter = integer -> Component.literal(String.format("Value: %d", integer));
+    private Function<Integer, Component> textGetter = integer -> Component.translatable("text.cloth-config.value", value);
     private final List<AbstractWidget> widgets;
     
     @ApiStatus.Internal

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
@@ -21,8 +21,6 @@ package me.shedaniel.clothconfig2.gui.entries;
 
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.Window;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractSliderButton;
@@ -43,7 +41,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-@Environment(EnvType.CLIENT)
 public class LongSliderEntry extends TooltipListEntry<Long> {
     
     protected Slider sliderWidget;

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
@@ -21,6 +21,8 @@ package me.shedaniel.clothconfig2.gui.entries;
 
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.Window;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractSliderButton;
@@ -41,6 +43,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+@Environment(EnvType.CLIENT)
 public class LongSliderEntry extends TooltipListEntry<Long> {
     
     protected Slider sliderWidget;
@@ -49,7 +52,7 @@ public class LongSliderEntry extends TooltipListEntry<Long> {
     protected final long orginial;
     private long minimum, maximum;
     private final Supplier<Long> defaultValue;
-    private Function<Long, Component> textGetter = value -> Component.literal(String.format("Value: %d", value));
+    private Function<Long, Component> textGetter = value -> Component.translatable("text.cloth-config.value", value);
     private final List<AbstractWidget> widgets;
     
     @ApiStatus.Internal

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/widget/SearchFieldEntry.java
@@ -113,7 +113,7 @@ public class SearchFieldEntry extends AbstractConfigListEntry<Object> {
         this.editBox.setY(y + entryHeight / 2 - 9);
         this.editBox.render(graphics, mouseX, mouseY, delta);
         if (this.editBox.getValue().isEmpty()) {
-            this.editBox.setSuggestion("Search...");
+            this.editBox.setSuggestion(Component.translatable("text.cloth-config.search").getString());
         } else {
             this.editBox.setSuggestion(null);
         }

--- a/common/src/main/resources/assets/cloth-config2/lang/en_us.json
+++ b/common/src/main/resources/assets/cloth-config2/lang/en_us.json
@@ -26,6 +26,8 @@
     "text.cloth-config.error_cannot_save": "Error!",
     "text.cloth-config.reset_value": "Reset",
     "text.cloth.reset_value": "Reset",
+    "text.cloth-config.search": "Search...",
+    "text.cloth-config.value": "Value: %d",
     "text.cloth-config.restart_required": "Restart Required",
     "text.cloth-config.restart_required_sub": "One of your modified settings requires Minecraft to be restarted. Do you want to proceed?",
     "text.cloth-config.exit_minecraft": "Exit Minecraft",


### PR DESCRIPTION
@shedaniel
Of course, this may not be the best way to do it, but everything seems to work correctly.

For example, here is Ukrainian(Although I haven't included any languages ​​other than English here).
<img width="204" height="92" alt="image" src="https://github.com/user-attachments/assets/0178ef05-da31-469c-bf46-ef736f5f3e70" />
<img width="255" height="78" alt="image" src="https://github.com/user-attachments/assets/a07b6710-9dc4-4ee2-a48d-0b7cdfd7ce00" />

