### PR TITLE
Simpler fix for #333

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
@@ -194,8 +194,9 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
             this.value = integer;
         }
         
+        @Override
         public void setValue(double integer) {
-            this.value = integer;
+            super.setValue(integer);
         }
     }
     

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/IntegerSliderEntry.java
@@ -169,9 +169,7 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
         
         @Override
         protected void applyValue() {
-            this.value = Mth.clamp(this.value, 0.0d, 1.0d);
             IntegerSliderEntry.this.value.set((int) (minimum + Math.abs(maximum - minimum) * value));
-            updateMessage();
         }
         
         @Override
@@ -185,8 +183,6 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
         public boolean mouseDragged(MouseButtonEvent event, double double_3, double double_4) {
             if (!isEditable())
                 return false;
-            this.value = Mth.clamp(this.value, 0.0d, 1.0d);
-            applyValue();
             return super.mouseDragged(event, double_3, double_4);
         }
         
@@ -196,12 +192,10 @@ public class IntegerSliderEntry extends TooltipListEntry<Integer> {
         
         public void setProgress(double integer) {
             this.value = integer;
-            applyValue();
         }
         
         public void setValue(double integer) {
-            this.value = Mth.clamp(integer, 0.0d, 1.0d);
-            applyValue();
+            this.value = integer;
         }
     }
     

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
@@ -169,9 +169,7 @@ public class LongSliderEntry extends TooltipListEntry<Long> {
         
         @Override
         protected void applyValue() {
-            this.value = Mth.clamp(this.value, 0.0d, 1.0d);
             LongSliderEntry.this.value.set((long) (minimum + Math.abs(maximum - minimum) * value));
-            updateMessage();
         }
         
         @Override
@@ -185,8 +183,6 @@ public class LongSliderEntry extends TooltipListEntry<Long> {
         public boolean mouseDragged(MouseButtonEvent event, double double_3, double double_4) {
             if (!isEditable())
                 return false;
-            this.value = Mth.clamp(this.value, 0.0d, 1.0d);
-            applyValue();
             return super.mouseDragged(event, double_3, double_4);
         }
         
@@ -195,8 +191,7 @@ public class LongSliderEntry extends TooltipListEntry<Long> {
         }
         
         public void setValue(double integer) {
-            this.value = Mth.clamp(integer, 0.0d, 1.0d);
-            applyValue();
+            this.value = integer;
         }
     }
     

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/LongSliderEntry.java
@@ -190,8 +190,9 @@ public class LongSliderEntry extends TooltipListEntry<Long> {
             return value;
         }
         
+        @Override
         public void setValue(double integer) {
-            this.value = integer;
+            super.setValue(integer);
         }
     }
     


### PR DESCRIPTION
Follow up to #335, this reverts #335 and applies a simpler fix.

`AbstractSliderButton.setValue` now has important internal logic:
```java
protected void setValue(double newValue) {
    double oldValue = this.value;
    this.value = Mth.clamp(newValue, 0.0D, 1.0D);
    if (oldValue != this.value) {
        this.applyValue();
    }
    this.updateMessage();
}
```

In particular, it is now responsible for calling `applyValue` and `updateMessage`.

The root cause of #333 is that the slider widgets override and shadow `setValue`. An override is still needed to make the method `public`, however it should delegate to `super.setValue`.

Fixes #333
