### PR TITLE
Fix SubCategoryListEntry being marked as require restart incorrectly

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
@@ -77,7 +77,7 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     @Override
     public boolean isRequiresRestart() {
         for (AbstractConfigListEntry entry : entries)
-            if (entry.isRequiresRestart())
+            if (entry.isRequiresRestart() && entry.isEdited())
                 return true;
         return false;
     }


### PR DESCRIPTION
Fix the weird behaviour where as long as `SubCategoryListEntry` contain any entry that require restart, the entire `SubCategoryListEntry` get marked as require restart, even when the field in question haven't been edited.

My apologies if this is an intended behaviour!