### PR TITLE
fix: nested list cells lose keyboard focus immediately after click

### DIFF
--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/AbstractTextFieldListListEntry.java
@@ -72,12 +72,6 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
             
             widget = new EditBox(Minecraft.getInstance().font, 0, 0, 100, 18, Component.empty()) {
                 @Override
-                public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
-                    setFocused(isSelected);
-                    super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
-                }
-
-                @Override
                 public void insertText(String input) {
                     String before = this.getValue();
                     super.insertText(input);
@@ -98,6 +92,7 @@ public abstract class AbstractTextFieldListListEntry<T, C extends AbstractTextFi
         @Override
         public void updateSelected(boolean isSelected) {
             this.isSelected = isSelected;
+            widget.setFocused(isSelected);
         }
         
         /**

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/BaseListEntry.java
@@ -229,6 +229,10 @@ public abstract class BaseListEntry<T, C extends BaseListCell, SELF extends Base
     }
     
     @Override
+    public void setFocused(boolean focused) {
+    }
+    
+    @Override
     public List<? extends NarratableEntry> narratables() {
         return narratables;
     }

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/DropdownBoxEntry.java
@@ -112,8 +112,12 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
     
     @Override
     public void updateSelected(boolean isSelected) {
-        selectionElement.topRenderer.isSelected = isSelected;
+        selectionElement.topRenderer.updateSelected(isSelected);
         selectionElement.menu.isSelected = isSelected;
+    }
+
+    @Override
+    public void setFocused(boolean focused) {
     }
     
     @NotNull
@@ -231,7 +235,11 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         public List<? extends GuiEventListener> children() {
             return Lists.newArrayList(topRenderer, menu);
         }
-        
+
+        @Override
+        public void setFocused(boolean focused) {
+        }
+
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
             dontReFocus = false;
@@ -659,7 +667,15 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
         @Deprecated private final Rectangle bounds = new Rectangle();
         @Deprecated private DropdownBoxEntry<R> entry;
         protected boolean isSelected = false;
-        
+
+        public void updateSelected(boolean isSelected) {
+            this.isSelected = isSelected;
+        }
+
+        @Override
+        public void setFocused(boolean focused) {
+        }
+
         public abstract R getValue();
         
         public abstract void setValue(R value);
@@ -733,12 +749,6 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             this.toTextFunction = Objects.requireNonNull(toTextFunction);
             textFieldWidget = new EditBox(Minecraft.getInstance().font, 0, 0, 148, 18, Component.empty()) {
                 @Override
-                public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
-                    setFocused(isSuggestionMode() && isSelected && DefaultSelectionTopCellElement.this.getParent().getFocused() == DefaultSelectionTopCellElement.this.getParent().selectionElement && DefaultSelectionTopCellElement.this.getParent().selectionElement.getFocused() == DefaultSelectionTopCellElement.this && DefaultSelectionTopCellElement.this.getFocused() == this);
-                    super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
-                }
-                
-                @Override
                 public boolean keyPressed(KeyEvent event) {
                     if (event.key() == GLFW.GLFW_KEY_ENTER || event.key() == GLFW.GLFW_KEY_ESCAPE) {
                         DefaultSelectionTopCellElement.this.selectFirstRecommendation();
@@ -756,7 +766,13 @@ public class DropdownBoxEntry<T> extends TooltipListEntry<T> {
             textFieldWidget.setMaxLength(999999);
             textFieldWidget.setValue(toTextFunction.apply(value).getString());
         }
-        
+
+        @Override
+        public void updateSelected(boolean isSelected) {
+            super.updateSelected(isSelected);
+            textFieldWidget.setFocused(isSuggestionMode() && isSelected && getParent().selectionElement.getFocused() == this);
+        }
+
         @Override
         public boolean isEdited() {
             return super.isEdited() || !getValue().equals(original);

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/MultiElementListEntry.java
@@ -208,7 +208,11 @@ public class MultiElementListEntry<T> extends TooltipListEntry<T> implements Exp
     public List<? extends GuiEventListener> children() {
         return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
-    
+
+    @Override
+    public void setFocused(boolean focused) {
+    }
+
     @Override
     public List<? extends NarratableEntry> narratables() {
         return isExpanded() ? (List) children : Collections.singletonList(widget);

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/SubCategoryListEntry.java
@@ -263,7 +263,11 @@ public class SubCategoryListEntry extends TooltipListEntry<List<AbstractConfigLi
     public List<? extends GuiEventListener> children() {
         return isExpanded() ? (List) children : Collections.singletonList(widget);
     }
-    
+
+    @Override
+    public void setFocused(boolean focused) {
+    }
+
     @Override
     public List<? extends NarratableEntry> narratables() {
         return isExpanded() ? (List) children : Collections.singletonList(widget);

--- a/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TextFieldListEntry.java
+++ b/common/src/main/java/me/shedaniel/clothconfig2/gui/entries/TextFieldListEntry.java
@@ -65,7 +65,6 @@ public abstract class TextFieldListEntry<T> extends TooltipListEntry<T> {
         this.textFieldWidget = new EditBox(Minecraft.getInstance().font, 0, 0, 148, 18, Component.empty()) {
             @Override
             public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int int_1, int int_2, float float_1) {
-                setFocused(isSelected && TextFieldListEntry.this.getFocused() == this);
                 textFieldPreRender(this);
                 super.extractWidgetRenderState(graphics, int_1, int_2, float_1);
             }
@@ -112,6 +111,7 @@ public abstract class TextFieldListEntry<T> extends TooltipListEntry<T> {
     @Override
     public void updateSelected(boolean isSelected) {
         this.isSelected = isSelected;
+        textFieldWidget.setFocused(isSelected);
     }
     
     @Override


### PR DESCRIPTION
Fixes #357.

Since the MC 26.1 API changes, `BaseListEntry` now acts both as a focus target for its parent (`SubCategoryListEntry`) and as a container tracking the selected cell via `getFocused()`. Re-applying focus from the parent ends up clearing the nested cell selection, even though focus hasn't actually changed.

This PR moves `EditBox#setFocused(isSelected)` into `updateSelected(boolean)` and overrides `BaseListEntry#setFocused(boolean)` as a no-op to preserve nested cell selection.