### PR TITLE
Implements #359 - Class level tooltip annotation

### DIFF
--- a/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/annotation/ConfigEntry.java
@@ -115,6 +115,23 @@ public class ConfigEntry {
         }
         
         /**
+         * Applies a tooltip to every field that supports it, defined in your lang file.
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.TYPE)
+        public @interface GlobalTooltip {
+            int count() default 1;
+        }
+        
+        /**
+         * Prevents {@link ConfigEntry.Gui.GlobalTooltip} from working on the given field.
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.FIELD)
+        public @interface SkipGlobalTooltip {
+        }
+        
+        /**
          * Applies no tooltip to list entries that support it, defined in your lang file.
          */
         @Retention(RetentionPolicy.RUNTIME)

--- a/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiTransformers.java
+++ b/common/src/main/java/me/shedaniel/autoconfig/gui/DefaultGuiTransformers.java
@@ -31,6 +31,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Locale;
@@ -48,14 +49,19 @@ public class DefaultGuiTransformers {
     
     public static GuiRegistry apply(GuiRegistry registry) {
         
-        registry.registerAnnotationTransformer(
+        registry.registerPredicateTransformer(
                 (guis, i18n, field, config, defaults, guiProvider) -> guis.stream()
                         .peek(gui -> {
                             if (!(gui instanceof TextListEntry)) {
                                 ConfigEntry.Gui.Tooltip tooltip = field.getAnnotation(ConfigEntry.Gui.Tooltip.class);
-                                if (tooltip.count() == 0) {
+                                ConfigEntry.Gui.GlobalTooltip globalTooltip = getGlobalTooltip(field);
+                                
+                                final int globalCount = globalTooltip != null ? globalTooltip.count() : 0;
+                                final int count = tooltip != null ? tooltip.count() : globalCount;
+                                
+                                if (count == 0) {
                                     tryRemoveTooltip(gui);
-                                } else if (tooltip.count() == 1) {
+                                } else if (count == 1) {
                                     tryApplyTooltip(
                                             gui,
                                             new Component[]{
@@ -64,7 +70,7 @@ public class DefaultGuiTransformers {
                                     );
                                 } else {
                                     tryApplyTooltip(
-                                            gui, IntStream.range(0, tooltip.count()).boxed()
+                                            gui, IntStream.range(0, count).boxed()
                                                     .map(i -> String.format("%s.%s[%d]", i18n, "@Tooltip", i))
                                                     .map(Component::translatable)
                                                     .toArray(Component[]::new)
@@ -73,7 +79,8 @@ public class DefaultGuiTransformers {
                             }
                         })
                         .collect(Collectors.toList()),
-                ConfigEntry.Gui.Tooltip.class
+                field -> field.isAnnotationPresent(ConfigEntry.Gui.Tooltip.class) ||
+                        (getGlobalTooltip(field) != null && !field.isAnnotationPresent(ConfigEntry.Gui.SkipGlobalTooltip.class))
         );
         
         registry.registerAnnotationTransformer(
@@ -127,6 +134,21 @@ public class DefaultGuiTransformers {
         );
         
         return registry;
+    }
+    
+    /**
+     * Checks if any of the parent classes have the {@link ConfigEntry.Gui.GlobalTooltip} annotation
+     * @return {@link ConfigEntry.Gui.GlobalTooltip} annotation instance if found, else null
+     */
+    public static ConfigEntry.Gui.GlobalTooltip getGlobalTooltip(Field field) {
+        Class<?> currentClass = field.getDeclaringClass();
+        while (currentClass != null) {
+            if (currentClass.isAnnotationPresent(ConfigEntry.Gui.GlobalTooltip.class)) {
+                return currentClass.getAnnotation(ConfigEntry.Gui.GlobalTooltip.class);
+            }
+            currentClass = currentClass.getEnclosingClass();
+        }
+        return null;
     }
     
     private static void tryApplyTooltip(AbstractConfigListEntry gui, Component[] text) {


### PR DESCRIPTION
Implements #359
Adds class level global tooltip annotation and a way to block it from working locally on a field.  
This is an implementation for 1.20(.1) as I just happened to be on this version in my mod, but I can port this to any versions required for the merge to happen :)