### PR TITLE
Conflict with Cloth API

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,6 +29,9 @@
         "fabricloader": ">=0.14.0",
         "minecraft": ">=26.2-"
     },
+    "breaks": {
+        "cloth-api": "*"
+    },
     "accessWidener": "cloth-config.accessWidener",
     "custom": {
         "modmenu": {


### PR DESCRIPTION
I've noticed that various mods on CurseForge [still mistakingly depend](https://www.curseforge.com/minecraft/mc-mods/cloth-api/relations/dependents?pageSize=20&page=1) on [Cloth API](https://www.curseforge.com/minecraft/mc-mods/cloth-api), as opposed to this - Cloth Config API. Often, they could even do both at the same time.

Unfortunately, the latest version of Cloth API does not have an upper limit of Minecraft version, causing a weird crash for the user. Therefore, I suggest adding this to the manifest of Cloth Config API, so that the user would realize their launcher downloaded the wrong thing and could remove it right away.