### PR TITLE
Fix & update mod metadata; support NeoForge iconFile

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -8,9 +8,9 @@
         "shedaniel"
     ],
     "contact": {
-        "homepage": "https://minecraft.curseforge.com/projects/cloth-config",
-        "sources": "https://github.com/shedaniel/ClothConfig",
-        "issues": "https://github.com/shedaniel/ClothConfig/issues"
+        "homepage": "https://modrinth.com/mod/cloth-config",
+        "sources": "https://github.com/shedaniel/cloth-config",
+        "issues": "https://github.com/shedaniel/cloth-config/issues"
     },
     "license": "GNU LGPLv3",
     "icon": "icon.png",

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,15 +1,15 @@
 modLoader = "javafml"
 loaderVersion = "[34,)"
 issueTrackerURL = "https://github.com/architectury/ClothConfig/issues/"
-displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
-logoFile = "icon.png"
-authors = "shedaniel"
 license = "GNU LGPLv3"
 
 [[mods]]
 modId = "cloth_config"
 version = "${version}"
 displayName = "Cloth Config v14 API"
+displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
+logoFile = "icon.png"
+authors = "shedaniel"
 description = '''
 An API for config screens.
 '''

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,13 +1,13 @@
 modLoader = "javafml"
 loaderVersion = "[34,)"
-issueTrackerURL = "https://github.com/architectury/ClothConfig/issues/"
+issueTrackerURL = "https://github.com/shedaniel/cloth-config/issues/"
 license = "GNU LGPLv3"
 
 [[mods]]
 modId = "cloth_config"
 version = "${version}"
 displayName = "Cloth Config v14 API"
-displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
+displayURL = "https://modrinth.com/mod/cloth-config"
 logoFile = "icon.png"
 authors = "shedaniel"
 description = '''

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -8,7 +8,7 @@ modId = "cloth_config"
 version = "${version}"
 displayName = "Cloth Config v26.2 API"
 displayURL = "https://modrinth.com/mod/cloth-config"
-logoFile = "icon.png"
+iconFile = "icon.png"
 authors = "shedaniel"
 description = '''
 An API for config screens.

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,15 +1,15 @@
 modLoader = "javafml"
 loaderVersion = "[1,)"
 issueTrackerURL = "https://github.com/architectury/ClothConfig/issues/"
-displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
-logoFile = "icon.png"
-authors = "shedaniel"
 license = "GNU LGPLv3"
 
 [[mods]]
 modId = "cloth_config"
 version = "${version}"
 displayName = "Cloth Config v26.2 API"
+displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
+logoFile = "icon.png"
+authors = "shedaniel"
 description = '''
 An API for config screens.
 '''

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,13 +1,13 @@
 modLoader = "javafml"
 loaderVersion = "[1,)"
-issueTrackerURL = "https://github.com/architectury/ClothConfig/issues/"
+issueTrackerURL = "https://github.com/shedaniel/cloth-config/issues/"
 license = "GNU LGPLv3"
 
 [[mods]]
 modId = "cloth_config"
 version = "${version}"
 displayName = "Cloth Config v26.2 API"
-displayURL = "https://www.curseforge.com/minecraft/mc-mods/cloth-config-forge/"
+displayURL = "https://modrinth.com/mod/cloth-config"
 logoFile = "icon.png"
 authors = "shedaniel"
 description = '''


### PR DESCRIPTION
- **Fix (Neo)Forge Mod-Specific Properties**
  - Can be backported to all versions

Some FML metadata fields were defined at the wrong level; mod-specific fields were defined at the file-level.

- **Update mod URLs**
  - Can be backported to all versions

The GitHub URLs were outdated, and modrinth now seems to be a more popular homepage than curseforge.

- **Update NeoForge logoFile → iconFile**
  - Should not be backported, applies only to 26.2+

As of 26.2.0.50-beta and the 26.2 stable versions, NeoForge have (loudly) deprecated `logoFile`. Instead, we now have `iconFile` (for a square icon) and `bannerFile` (for a wide banner).
